### PR TITLE
お問い合わせ対応 #33　科目の順序変更

### DIFF
--- a/iOS/Accountant/v1.0/Program/src/Accountant/AppDelegate.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/AppDelegate.swift
@@ -284,6 +284,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         userDefaults.register(defaults: firstLunch)
         // 動作確認用
         // userDefaults.set(true, forKey: firstLunchKey)
+        // 設定勘定科目　初期化
+        firstLunchKey = "settings_taxonomy_account"
+        firstLunch = [firstLunchKey: true]
+        userDefaults.register(defaults: firstLunch)
+        // 動作確認用
+        // userDefaults.set(true, forKey: firstLunchKey)
+        // 設定表示科目　初期化
+        firstLunchKey = "settings_taxonomy"
+        firstLunch = [firstLunchKey: true]
+        userDefaults.register(defaults: firstLunch)
+        // 動作確認用
+        // userDefaults.set(true, forKey: firstLunchKey)
         // サンプル仕訳データ
         firstLunchKey = "sample_JournalEntry"
         firstLunch = [firstLunchKey: true]

--- a/iOS/Accountant/v1.0/Program/src/Accountant/AppDelegate.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let config = Realm.Configuration(
             // Set the new schema version. This must be greater than the previously used
             // version (if you've never set a schema version before, the version is 0).
-            schemaVersion: 4,
+            schemaVersion: 5,
             
             // Set the block which will be called automatically when opening a Realm with
             // a schema version lower than the one set above
@@ -110,6 +110,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     migration.enumerateObjects(ofType: DataBaseAccount.className()) { oldObject, newObject in
                         // 月次残高振替仕訳
                         newObject?["dataBaseMonthlyTransferEntries"] = List<DataBaseMonthlyTransferEntry>()
+                    }
+                }
+                // スキーマバージョン
+                if oldSchemaVersion < 5 {
+                    // DataBaseSettingsTaxonomyAccountオブジェクトを列挙します
+                    migration.enumerateObjects(ofType: DataBaseSettingsTaxonomyAccount.className()) { oldObject, newObject in
+                        // プロパティを追加します
+                        newObject?["serialNumber"] = oldObject?.number
                     }
                 }
             }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DataBaseManagerGeneralLedger.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DataBaseManagerGeneralLedger.swift
@@ -42,7 +42,7 @@ class DataBaseManagerGeneralLedger: DataBaseManager {
                     // オブジェクトを作成 勘定
                     let dataBaseAccount = DataBaseAccount(
                         fiscalYear: dataBaseAccountingBooks.fiscalYear,
-                        accountName: objects[i].category,
+                        accountName: objects[i].category, // MARK: 勘定科目名が使用されている
                         debit_total: 0,
                         credit_total: 0,
                         debit_balance: 0,

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
@@ -92,7 +92,7 @@ class DatabaseManagerSettingsTaxonomyAccount {
             return false // 損益計算書の科目ではない
         }
     }
-    // 取得　設定勘定科目　スイッチ　（精算表、試算表で使用している）
+    // 取得　設定勘定科目　スイッチ　（初期化処理で使用している）
     func getSettingsTaxonomyAccountAdjustingSwitch(adjustingAndClosingEntries: Bool, switching: Bool) -> Results<DataBaseSettingsTaxonomyAccount> {
         var objects = RealmManager.shared.readWithPredicate(type: DataBaseSettingsTaxonomyAccount.self, predicates: [
             // FIXME: 使用していないプロパティを使っている

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
@@ -11,9 +11,9 @@ import RealmSwift
 
 // 設定勘定科目クラス
 class DatabaseManagerSettingsTaxonomyAccount {
-
+    
     public static let shared = DatabaseManagerSettingsTaxonomyAccount()
-
+    
     private init() {
     }
     
@@ -218,9 +218,15 @@ class DatabaseManagerSettingsTaxonomyAccount {
         if let rank1 = rank1 {
             predicates.append(NSPredicate(format: "Rank1 LIKE %@", NSString(string: String(rank1)))) // 中区分　当座資産
         }
+        let sortProperties = [
+            SortDescriptor(keyPath: "Rank1", ascending: true), // 中区分
+            SortDescriptor(keyPath: "serialNumber", ascending: true) // シリアルナンバー
+        ]
         var objects = RealmManager.shared.readWithPredicate(type: DataBaseSettingsTaxonomyAccount.self, predicates: predicates)
-        // シリアルナンバー
-        objects = objects.sorted(byKeyPath: "serialNumber", ascending: true)
+            .sorted(by: sortProperties)
+        // MARK: 複数条件でソートする方法　下記の書き方では効かない
+        // objects = objects.sorted(byKeyPath: "Rank1", ascending: true)
+        // objects = objects.sorted(byKeyPath: "serialNumber", ascending: true)
         return objects
     }
     // 丁数を取得
@@ -240,7 +246,7 @@ class DatabaseManagerSettingsTaxonomyAccount {
             }
         }
     }
-
+    
     // MARK: Update
     
     // 初期化
@@ -283,18 +289,18 @@ class DatabaseManagerSettingsTaxonomyAccount {
             print("エラーが発生しました")
         }
     }
-    //    // 更新　勘定科目名を変更
-    //    func updateAccountNameOfSettingsTaxonomyAccount(number: Int, accountName: String) { // すべての影響範囲に修正が必要
-    //        do {
-    //            // (2)書き込みトランザクション内でデータを更新する
-    //            try DataBaseManager.realm.write {
-    //                let value: [String: Any] = ["number": number, "category": accountName]
-    //                DataBaseManager.realm.create(DataBaseSettingsTaxonomyAccount.self, value: value, update: .modified) // 一部上書き更新
-    //            }
-    //        } catch {
-    //            print("エラーが発生しました")
-    //        }
-    //    }
+    // 更新　勘定科目名を変更
+    func updateAccountNameOfSettingsTaxonomyAccount(number: Int, accountName: String) { // WARNING: すべての影響範囲に修正が必要(仕訳、勘定)
+        do {
+            // (2)書き込みトランザクション内でデータを更新する
+            try DataBaseManager.realm.write {
+                let value: [String: Any] = ["number": number, "category": accountName] // 勘定科目名
+                DataBaseManager.realm.create(DataBaseSettingsTaxonomyAccount.self, value: value, update: .modified) // 一部上書き更新
+            }
+        } catch {
+            print("エラーが発生しました")
+        }
+    }
     // 更新　設定勘定科目　設定勘定科目連番から、紐づける表示科目を変更
     func updateTaxonomyOfSettingsTaxonomyAccount(number: Int, numberOfTaxonomy: String) {
         do {
@@ -362,7 +368,7 @@ class DatabaseManagerSettingsTaxonomyAccount {
         }
         return false // 勘定を削除できたら、設定勘定科目を削除する
     }
-
+    
     // 削除　勘定、よく使う仕訳　設定勘定科目を削除するときに呼ばれる
     func deleteAccount(number: Int) -> Bool {
         // (2)データベース内に保存されているモデルを取得する　プライマリーキーを指定してオブジェクトを取得
@@ -392,7 +398,7 @@ class DatabaseManagerSettingsTaxonomyAccount {
         // よく使う仕訳
         let dataBaseSettingsOperatingJournalEntry = DataBaseManagerSettingsOperatingJournalEntry.shared.getJournalEntry(account: object.category)
         print(dataBaseSettingsOperatingJournalEntry)
-
+        
         // 仕訳クラス　仕訳を削除
         var isInvalidated = true // 初期値は真とする。仕訳データが0件の場合の対策
         var isInvalidated2 = true
@@ -429,7 +435,7 @@ class DatabaseManagerSettingsTaxonomyAccount {
         for _ in 0..<dataBaseSettingsOperatingJournalEntry.count {
             isInvalidated7 = DataBaseManagerSettingsOperatingJournalEntry.shared.deleteJournalEntry(number: dataBaseSettingsOperatingJournalEntry[0].number)
         }
-
+        
         if isInvalidated7 {
             if isInvalidated6 {
                 if isInvalidated5 {
@@ -457,5 +463,5 @@ class DatabaseManagerSettingsTaxonomyAccount {
         }
         return false
     }
-
+    
 }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
@@ -21,7 +21,7 @@ class DatabaseManagerSettingsTaxonomyAccount {
     
     // MARK: Create
     
-    // 追加　設定勘定科目　新規作成
+    // 追加　設定勘定科目　新規作成　（元入金、事業主貸、事業主借、新規の勘定科目を作成時に使用している）
     func addSettingsTaxonomyAccount(rank0: String, rank1: String, rank2: String, numberOfTaxonomy: String, category: String, switching: Bool) -> Int {
         // オブジェクトを作成
         let dataBaseSettingsTaxonomyAccount = DataBaseSettingsTaxonomyAccount(
@@ -38,6 +38,8 @@ class DatabaseManagerSettingsTaxonomyAccount {
         do {
             try DataBaseManager.realm.write {
                 number = dataBaseSettingsTaxonomyAccount.save() //　自動採番
+                // シリアルナンバー
+                dataBaseSettingsTaxonomyAccount.serialNumber = number
                 // 設定勘定科目を追加
                 DataBaseManager.realm.add(dataBaseSettingsTaxonomyAccount)
             }
@@ -308,6 +310,23 @@ class DatabaseManagerSettingsTaxonomyAccount {
             }
         } catch {
             print("エラーが発生しました")
+        }
+    }
+    
+    // 採番　並び替えの順序のためのシリアルナンバーを更新する
+    func makeSerialNumbers(objects: [SeializingObject]) {
+        // 採番をやりなおす
+        for sortedObject in objects.enumerated() {
+            print("採番:", sortedObject.0, "number:", sortedObject.1.number, "serialNumber:", sortedObject.1.serialNumber)
+            do {
+                // (2)書き込みトランザクション内でデータを更新する
+                try DataBaseManager.realm.write {
+                    let value: [String: Any] = ["number": sortedObject.1.number, "serialNumber": sortedObject.0]
+                    DataBaseManager.realm.create(DataBaseSettingsTaxonomyAccount.self, value: value, update: .modified) // 一部上書き更新
+                }
+            } catch {
+                print("エラーが発生しました")
+            }
         }
     }
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
@@ -100,6 +100,8 @@ class DatabaseManagerSettingsTaxonomyAccount {
             NSPredicate(format: "switching == %@", NSNumber(value: switching)) // 勘定科目がONだけに絞る
         ])
         objects = objects.sorted(byKeyPath: "number", ascending: true)
+        // MARK: シリアルナンバー
+        //　objects = objects.sorted(byKeyPath: "serialNumber", ascending: true) // 不要
         return objects
     }
     // 取得 全ての勘定科目
@@ -202,10 +204,11 @@ class DatabaseManagerSettingsTaxonomyAccount {
             predicates.append(NSPredicate(format: "Rank1 LIKE %@", NSString(string: String(rank1)))) // 中区分　当座資産
         }
         var objects = RealmManager.shared.readWithPredicate(type: DataBaseSettingsTaxonomyAccount.self, predicates: predicates)
-        objects = objects.sorted(byKeyPath: "number", ascending: true) // 引数:プロパティ名, ソート順は昇順か？
+        // シリアルナンバー
+        objects = objects.sorted(byKeyPath: "serialNumber", ascending: true)
         return objects
     }
-    // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+    // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（仕訳、総勘定元帳、貸借対照表、損益計算書、精算表、試算表 で使用している）
     func getDataBaseSettingsTaxonomyAccountInRankValid(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
         var predicates = [
             NSPredicate(format: "Rank0 LIKE %@", NSString(string: String(rank0))), // 大区分　流動資産
@@ -218,15 +221,6 @@ class DatabaseManagerSettingsTaxonomyAccount {
         var objects = RealmManager.shared.readWithPredicate(type: DataBaseSettingsTaxonomyAccount.self, predicates: predicates)
         // シリアルナンバー
         objects = objects.sorted(byKeyPath: "serialNumber", ascending: true)
-        return objects
-    }
-    // 取得 大区分別に、スイッチONの勘定科目　（仕訳画面勘定科目選択、総勘定元帳画面で使用している）
-    func getSettingsSwitchingOn(rank0: Int) -> Results<DataBaseSettingsTaxonomyAccount> {
-        var objects = RealmManager.shared.readWithPredicate(type: DataBaseSettingsTaxonomyAccount.self, predicates: [
-            NSPredicate(format: "Rank0 LIKE %@", NSString(string: String(rank0))),
-            NSPredicate(format: "switching == %@", NSNumber(value: true)) // 勘定科目がONだけに絞る
-        ])
-        objects = objects.sorted(byKeyPath: "number", ascending: true)
         return objects
     }
     // 丁数を取得

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseManager/DatabaseManagerSettingsTaxonomyAccount.swift
@@ -92,7 +92,7 @@ class DatabaseManagerSettingsTaxonomyAccount {
             return false // 損益計算書の科目ではない
         }
     }
-    // 取得　設定勘定科目　スイッチ
+    // 取得　設定勘定科目　スイッチ　（精算表、試算表で使用している）
     func getSettingsTaxonomyAccountAdjustingSwitch(adjustingAndClosingEntries: Bool, switching: Bool) -> Results<DataBaseSettingsTaxonomyAccount> {
         var objects = RealmManager.shared.readWithPredicate(type: DataBaseSettingsTaxonomyAccount.self, predicates: [
             // FIXME: 使用していないプロパティを使っている
@@ -192,7 +192,7 @@ class DatabaseManagerSettingsTaxonomyAccount {
         objects = objects.sorted(byKeyPath: "number", ascending: true)
         return objects
     }
-    // 取得 大区分、中区分、小区分
+    // 取得 大区分、中区分、小区分　（設定勘定科目一覧画面で使用している）
     func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
         var predicates = [
             NSPredicate(format: "Rank0 LIKE %@", NSString(string: String(rank0))) // 大区分　流動資産
@@ -205,7 +205,7 @@ class DatabaseManagerSettingsTaxonomyAccount {
         objects = objects.sorted(byKeyPath: "number", ascending: true) // 引数:プロパティ名, ソート順は昇順か？
         return objects
     }
-    // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主
+    // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
     func getDataBaseSettingsTaxonomyAccountInRankValid(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
         var predicates = [
             NSPredicate(format: "Rank0 LIKE %@", NSString(string: String(rank0))), // 大区分　流動資産
@@ -216,10 +216,11 @@ class DatabaseManagerSettingsTaxonomyAccount {
             predicates.append(NSPredicate(format: "Rank1 LIKE %@", NSString(string: String(rank1)))) // 中区分　当座資産
         }
         var objects = RealmManager.shared.readWithPredicate(type: DataBaseSettingsTaxonomyAccount.self, predicates: predicates)
-        objects = objects.sorted(byKeyPath: "number", ascending: true) // 引数:プロパティ名, ソート順は昇順か？
+        // シリアルナンバー
+        objects = objects.sorted(byKeyPath: "serialNumber", ascending: true)
         return objects
     }
-    // 取得 大区分別に、スイッチONの勘定科目
+    // 取得 大区分別に、スイッチONの勘定科目　（仕訳画面勘定科目選択、総勘定元帳画面で使用している）
     func getSettingsSwitchingOn(rank0: Int) -> Results<DataBaseSettingsTaxonomyAccount> {
         var objects = RealmManager.shared.readWithPredicate(type: DataBaseSettingsTaxonomyAccount.self, predicates: [
             NSPredicate(format: "Rank0 LIKE %@", NSString(string: String(rank0))),

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseModel/DataBaseSettingsTaxonomyAccount.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseModel/DataBaseSettingsTaxonomyAccount.swift
@@ -50,7 +50,7 @@ class DataBaseSettingsTaxonomyAccount: RObject {
     @objc dynamic var Rank2: String = ""                         // 小区分
     @objc dynamic var numberOfTaxonomy: String = ""             // タクソノミ表示科目クラス　の連番を保持する
     @objc dynamic var category: String = ""                      // 勘定科目名
-    @objc dynamic var AdjustingAndClosingEntries = false // 決算整理仕訳　使用していない2020/10/07
+    @objc dynamic var AdjustingAndClosingEntries = false // TODO: 決算整理仕訳　使用していない2020/10/07
     @objc dynamic var switching = false                    // 有効無効
     // @objc dynamic var explaining: String = ""              // 説明
 }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseModel/DataBaseSettingsTaxonomyAccount.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/DataBaseRealm/DataBaseModel/DataBaseSettingsTaxonomyAccount.swift
@@ -44,6 +44,7 @@ class DataBaseSettingsTaxonomyAccount: RObject {
         self.switching = switching
     }
 
+    @objc dynamic var serialNumber: Int = 0                    // シリアルナンバー　並び替えのための順序
     @objc dynamic var Rank0: String = ""                         // 大区分
     @objc dynamic var Rank1: String = ""                         // 中区分
     @objc dynamic var Rank2: String = ""                         // 小区分

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/Initial/Initial.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/Initial/Initial.swift
@@ -104,18 +104,42 @@ class Initial {
      * 設定勘定科目を初期化する。
      */
     func initialiseMasterData(completion: @escaping () -> Void) {
-        if !DatabaseManagerSettingsTaxonomyAccount.shared.checkInitialising() {
-            // すでに存在するオブジェクトを全て削除する v2.0.2で初期化処理が失敗している場合に対処する処理
-            DatabaseManagerSettingsTaxonomyAccount.shared.deleteAllOfSettingsTaxonomyAccount()
-            let masterData = MasterData()
-            // マスターデータを作成する
-            masterData.readMasterDataFromCSVOfTaxonomyAccount()
+        // 設定勘定科目　初期化　初回起動時
+        if UserDefaults.standard.bool(forKey: "settings_taxonomy_account") {
+            // 設定勘定科目　初期化 失敗している
+            if DatabaseManagerSettingsTaxonomyAccount.shared.checkInitialising() {
+                // フラグを倒す 設定勘定科目　初期化
+                let userDefaults = UserDefaults.standard
+                let firstLunchKey = "settings_taxonomy_account"
+                userDefaults.set(false, forKey: firstLunchKey)
+                userDefaults.synchronize()
+            } else {
+                // すでに存在するオブジェクトを全て削除する v2.0.2で初期化処理が失敗している場合に対処する処理
+                DatabaseManagerSettingsTaxonomyAccount.shared.deleteAllOfSettingsTaxonomyAccount()
+                let masterData = MasterData()
+                // マスターデータを作成する
+                masterData.readMasterDataFromCSVOfTaxonomyAccount()
+            }
+        } else {
+            // 設定勘定科目　初期化 済み
         }
-        if !DataBaseManagerSettingsTaxonomy.shared.checkInitialising() {
-            // すでに存在するオブジェクトを全て削除する v2.0.2で初期化処理が失敗している場合に対処する処理
-            DataBaseManagerSettingsTaxonomy.shared.deleteAllOfSettingsTaxonomy()
-            let masterData = MasterData()
-            masterData.readMasterDataFromCSVOfTaxonomy()
+        // 設定表示科目　初期化　初回起動時
+        if UserDefaults.standard.bool(forKey: "settings_taxonomy") {
+            // 設定勘定科目　初期化 失敗している
+            if DataBaseManagerSettingsTaxonomy.shared.checkInitialising() {
+                // フラグを倒す 設定表示科目　初期化
+                let userDefaults = UserDefaults.standard
+                let firstLunchKey = "settings_taxonomy"
+                userDefaults.set(false, forKey: firstLunchKey)
+                userDefaults.synchronize()
+            } else {
+                // すでに存在するオブジェクトを全て削除する v2.0.2で初期化処理が失敗している場合に対処する処理
+                DataBaseManagerSettingsTaxonomy.shared.deleteAllOfSettingsTaxonomy()
+                let masterData = MasterData()
+                masterData.readMasterDataFromCSVOfTaxonomy()
+            }
+        } else {
+            // 設定表示科目　初期化 済み
         }
         // 法人/個人フラグ
         if UserDefaults.standard.bool(forKey: "corporation_switch") {

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/Initial/MasterData/MasterData.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/Initial/MasterData/MasterData.swift
@@ -40,7 +40,7 @@ class MasterData {
                     Rank2: line.components(separatedBy: ",")[2], // 小区分
                     numberOfTaxonomy: line.components(separatedBy: ",")[3], // 紐づけた表示科目
                     category: line.components(separatedBy: ",")[4], // 勘定科目名
-                    AdjustingAndClosingEntries: false, // 決算整理仕訳　使用していない2020/10/07
+                    AdjustingAndClosingEntries: false, // TODO: 決算整理仕訳　使用していない 2020/10/07
                     switching: self.toBoolean(string: line.components(separatedBy: ",")[5]) // スイッチ
                 )
                 var number = 0 // 自動採番にした

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/Initial/MasterData/MasterData.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/Initial/MasterData/MasterData.swift
@@ -48,6 +48,8 @@ class MasterData {
                 do {
                     try DataBaseManager.realm.write {
                         number = dataBaseSettingsTaxonomyAccount.save() // 連番　自動採番
+                        // シリアルナンバー
+                        dataBaseSettingsTaxonomyAccount.serialNumber = number
                         DataBaseManager.realm.add(dataBaseSettingsTaxonomyAccount)
                     }
                 } catch {

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/Initial/MasterData/MasterData.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/Initial/MasterData/MasterData.swift
@@ -55,6 +55,12 @@ class MasterData {
                 }
                 print("連番: \(number), 勘定科目　CSVファイルを読み込み \(dataBaseSettingsTaxonomyAccount.numberOfTaxonomy)")
                 if number == 229 {
+                    // フラグを倒す 設定勘定科目　初期化
+                    let userDefaults = UserDefaults.standard
+                    let firstLunchKey = "settings_taxonomy_account"
+                    userDefaults.set(false, forKey: firstLunchKey)
+                    userDefaults.synchronize()
+                    
                     stop = true
                 }
             }
@@ -98,6 +104,12 @@ class MasterData {
                 }
                 print("連番: \(number) 表示科目　CSVファイルを読み込み")
                 if number == 2_068 {
+                    // フラグを倒す 設定表示科目　初期化
+                    let userDefaults = UserDefaults.standard
+                    let firstLunchKey = "settings_taxonomy"
+                    userDefaults.set(false, forKey: firstLunchKey)
+                    userDefaults.synchronize()
+                    
                     stop = true
                 }
             }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/AfterClosingTrialBalanceModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/AfterClosingTrialBalanceModel.swift
@@ -12,7 +12,8 @@ import RealmSwift
 /// GUIアーキテクチャ　MVP
 protocol AfterClosingTrialBalanceModelInput {
     func calculateAmountOfBSAccounts(dataBaseSettingsTaxonomyAccounts: Results<DataBaseSettingsTaxonomyAccount>)
-    
+    func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount>
+
     func getTotalAmountAfterAdjusting(account: String, leftOrRight: Int) -> Int64
 }
 
@@ -24,6 +25,12 @@ class AfterClosingTrialBalanceModel: AfterClosingTrialBalanceModelInput {
     // MARK: Create
     
     // MARK: Read
+    
+    // 取得 大区分、中区分、小区分 スイッチONの勘定科目
+    func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+        DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
+    }
     
     // 取得　決算整理後　勘定クラス　合計、残高　勘定別の決算整理後の合計額
     func getTotalAmountAfterAdjusting(account: String, leftOrRight: Int) -> Int64 {

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/AfterClosingTrialBalanceModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/AfterClosingTrialBalanceModel.swift
@@ -28,7 +28,7 @@ class AfterClosingTrialBalanceModel: AfterClosingTrialBalanceModelInput {
     
     // 取得 大区分、中区分、小区分 スイッチONの勘定科目
     func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
-        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（仕訳、総勘定元帳、貸借対照表、損益計算書、精算表、試算表 で使用している）
         DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
     }
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/BalanceSheetModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/BalanceSheetModel.swift
@@ -35,7 +35,7 @@ class BalanceSheetModel: BalanceSheetModelInput {
     
     // 取得 大区分、中区分、小区分 スイッチONの勘定科目
     func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
-        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（仕訳、総勘定元帳、貸借対照表、損益計算書、精算表、試算表 で使用している）
         DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
     }
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/BalanceSheetModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/BalanceSheetModel.swift
@@ -35,6 +35,7 @@ class BalanceSheetModel: BalanceSheetModelInput {
     
     // 取得 大区分、中区分、小区分 スイッチONの勘定科目
     func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
         DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
     }
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/CategoryListModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/CategoryListModel.swift
@@ -33,7 +33,8 @@ class CategoryListModel: CategoryListModelInput {
     }
     // 取得 大区分別に、スイッチONの勘定科目
     func getSettingsSwitchingOn(rank0: Int) -> Results<DataBaseSettingsTaxonomyAccount> {
-        DatabaseManagerSettingsTaxonomyAccount.shared.getSettingsSwitchingOn(rank0: rank0)
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（仕訳、総勘定元帳、貸借対照表、損益計算書、精算表、試算表 で使用している）
+        DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: nil)
     }
     
     // MARK: Update

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/CategoryListModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/CategoryListModel.swift
@@ -18,7 +18,7 @@ protocol CategoryListModelInput {
     func deleteSettingsTaxonomyAccount(number: Int) -> Bool
 }
 
-// クラス
+// 設定勘定科目一覧　画面　クラス
 class CategoryListModel: CategoryListModelInput {
     
     // MARK: - CRUD

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/OpeningBalanceModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/OpeningBalanceModel.swift
@@ -124,7 +124,7 @@ class OpeningBalanceModel: OpeningBalanceModelInput {
     
     // 取得 大区分、中区分、小区分 スイッチONの勘定科目
     func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
-        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（仕訳、総勘定元帳、貸借対照表、損益計算書、精算表、試算表 で使用している）
         DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
     }
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/ProfitAndLossStatementModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/ProfitAndLossStatementModel.swift
@@ -35,7 +35,7 @@ class ProfitAndLossStatementModel: ProfitAndLossStatementModelInput {
     
     // 取得 大区分、中区分、小区分 スイッチONの勘定科目
     func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
-        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（仕訳、総勘定元帳、貸借対照表、損益計算書、精算表、試算表 で使用している）
         DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
     }
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/ProfitAndLossStatementModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/ProfitAndLossStatementModel.swift
@@ -35,6 +35,7 @@ class ProfitAndLossStatementModel: ProfitAndLossStatementModelInput {
     
     // 取得 大区分、中区分、小区分 スイッチONの勘定科目
     func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
         DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
     }
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/TBModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/TBModel.swift
@@ -29,7 +29,7 @@ class TBModel: TBModelInput {
     
     // 取得 大区分、中区分、小区分 スイッチONの勘定科目
     func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
-        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（仕訳、総勘定元帳、貸借対照表、損益計算書、精算表、試算表 で使用している）
         DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
     }
 

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/TBModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/TBModel.swift
@@ -13,7 +13,8 @@ import RealmSwift
 protocol TBModelInput {
     func calculateAmountOfAllAccount()
     func setAllAccountTotal()
-    
+    func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount>
+
     func getTotalAmount(account: String, leftOrRight: Int) -> Int64
 }
 
@@ -26,6 +27,12 @@ class TBModel: TBModelInput {
     
     // MARK: Read
     
+    // 取得 大区分、中区分、小区分 スイッチONの勘定科目
+    func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+        DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
+    }
+
     // 取得　決算整理前　勘定クラス　合計、残高　勘定別の決算整理前の合計残高
     func getTotalAmount(account: String, leftOrRight: Int) -> Int64 {
         var result: Int64 = 0

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/WSModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/WSModel.swift
@@ -30,7 +30,7 @@ class WSModel: WSModelInput {
     
     // 取得 大区分、中区分、小区分 スイッチONの勘定科目
     func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
-        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（仕訳、総勘定元帳、貸借対照表、損益計算書、精算表、試算表 で使用している）
         DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
     }
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/WSModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/WSModel.swift
@@ -11,9 +11,10 @@ import RealmSwift
 
 /// GUIアーキテクチャ　MVP
 protocol WSModelInput {
-    
     func initialize()
     
+    func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount>
+
     func getTotalAmount(account: String, leftOrRight: Int) -> String
     func getTotalAmountAdjusting(account: String, leftOrRight: Int) -> String
     func getTotalAmountAfterAdjusting(account: String, leftOrRight: Int) -> String
@@ -26,7 +27,13 @@ class WSModel: WSModelInput {
     // MARK: Create
 
     // MARK: Read
-
+    
+    // 取得 大区分、中区分、小区分 スイッチONの勘定科目
+    func getDataBaseSettingsTaxonomyAccountInRank(rank0: Int, rank1: Int?) -> Results<DataBaseSettingsTaxonomyAccount> {
+        // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（貸借対照表、損益計算書、精算表、試算表で使用している）
+        DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: rank0, rank1: rank1)
+    }
+    
     // 取得　決算整理前　勘定クラス　合計、残高　勘定別の決算整理前の合計残高
     func getTotalAmount(account: String, leftOrRight: Int) -> String {
         let databaseManager = TBModel()

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Utils/Toast.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Utils/Toast.swift
@@ -33,10 +33,46 @@ enum Toast {
                 width: width,
                 height: height
             )
+            UIView.animate(
+                withDuration: 1.0,
+                delay: 3.0,
+                options: .curveEaseOut,
+                animations: {
+                    label.alpha = 0.0
+                }, completion: { _ in
+                    label.removeFromSuperview()
+                }
+            )
+        }
+    }
+    
+    internal static func show(_ text: String, _ parent: UITableView) {
+        DispatchQueue.main.async {
+            let label = UILabel()
+            let width = 300.0
+            let height = 50.0
+            var bottomPadding = 0.0
+            if #available(iOS 13.0, *) {
+                let scenes = UIApplication.shared.connectedScenes
+                let windowScene = scenes.first as? UIWindowScene
+                if let window = windowScene?.windows.first {
+                    bottomPadding = window.safeAreaInsets.bottom
+                }
+            }
+            label.backgroundColor = UIColor.red.withAlphaComponent(0.8)
+            label.textColor = UIColor.white
+            label.textAlignment = .center
+            label.text = text
+            label.frame = CGRect(
+                x: parent.frame.size.width * 0.5 - (width / 2),
+                y: parent.frame.size.height - height - bottomPadding + parent.contentOffset.y, // スクロールした分を加味する
+                width: width,
+                height: height
+            )
             parent.addSubview(label)
             
             UIView.animate(
-                withDuration: 1.0, 
+                withDuration: 1.0,
                 delay: 3.0,
                 options: .curveEaseOut,
                 animations: {

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/JournalEntry/PickerTextField.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/JournalEntry/PickerTextField.swift
@@ -147,7 +147,9 @@ class PickerTextField: UITextField {
     func getSettingsCategoryFromDB() {
         // データベース
         for i in 0..<Rank0.allCases.count {
-            let objects = DatabaseManagerSettingsTaxonomyAccount.shared.getSettingsSwitchingOn(rank0: i) // どのセクションに表示するセルかを判別するため引数で渡す
+            // 取得 大区分、中区分、小区分 スイッチONの勘定科目 個人事業主　（仕訳、総勘定元帳、貸借対照表、損益計算書、精算表、試算表 で使用している）
+            let objects = DatabaseManagerSettingsTaxonomyAccount.shared.getDataBaseSettingsTaxonomyAccountInRankValid(rank0: i, rank1: nil)
+            // どのセクションに表示するセルかを判別するため引数で渡す
             //　let items = transferItems(objects: objects) // 区分ごとの勘定科目が入ったArrayリストが返る
             var items: [String] = []
             for y in 0..<objects.count {    // 勘定

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/AfterClosingTrialBalancePresenter.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/AfterClosingTrialBalancePresenter.swift
@@ -15,11 +15,15 @@ protocol AfterClosingTrialBalancePresenterInput {
     var company: String? { get }
     var fiscalYear: Int? { get }
     var theDayOfReckoning: String? { get }
-    
+
     var numberOfobjects: Int { get }
     
     func objects(forRow row: Int) -> DataBaseSettingsTaxonomyAccount
-    
+
+    func numberOfsections() -> Int
+    func numberOfobjects(section: Int) -> Int
+    func objects(forRow row: Int, section: Int) -> DataBaseSettingsTaxonomyAccount
+
     func viewDidLoad()
     func viewWillAppear()
     func viewWillDisappear()
@@ -47,6 +51,20 @@ final class AfterClosingTrialBalancePresenter: AfterClosingTrialBalancePresenter
     var theDayOfReckoning: String?
     // 設定勘定科目 貸借科目
     private var dataBaseSettingsTaxonomyAccounts: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects0: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects1: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects2: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects3: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects4: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects5: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects6: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects7: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects8: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects9: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects10: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects11: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects12: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects13: Results<DataBaseSettingsTaxonomyAccount>
     // 財務諸表
     private var object: DataBaseFinancialStatements
     
@@ -58,6 +76,26 @@ final class AfterClosingTrialBalancePresenter: AfterClosingTrialBalancePresenter
         self.model = model
         // 設定勘定科目 貸借科目
         dataBaseSettingsTaxonomyAccounts = DatabaseManagerSettingsTaxonomyAccount.shared.getSettingsSwitchingOnBSorPL(BSorPL: 0) // 貸借対照表　資産 負債 純資産
+        objects0 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 0)
+        objects1 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 1)
+        objects2 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 2)
+        
+        objects3 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 3)
+        objects4 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 4)
+        objects5 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 5)
+        
+        objects6 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 2, rank1: 6)
+        
+        objects7 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 3, rank1: 7)
+        objects8 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 3, rank1: 8)
+        
+        objects9 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 4, rank1: 9)
+        
+        objects10 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 10)
+        objects11 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 11)
+        objects12 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 12)
+        objects13 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 19)
+
         // 財務諸表
         object = DataBaseManagerFinancialStatements.shared.getFinancialStatements()
     }
@@ -98,6 +136,64 @@ final class AfterClosingTrialBalancePresenter: AfterClosingTrialBalancePresenter
         dataBaseSettingsTaxonomyAccounts[row]
     }
     
+    func numberOfsections() -> Int {
+        14
+    }
+    
+    func numberOfobjects(section: Int) -> Int {
+        switch section {
+            //     "流動資産"
+        case 0: return objects0.count
+        case 1: return objects1.count
+        case 2: return objects2.count
+            //     "固定資産"
+        case 3: return objects3.count
+        case 4: return objects4.count
+        case 5: return objects5.count
+            //     "繰延資産"
+        case 6: return objects6.count
+            //     "流動負債"
+        case 7: return objects7.count
+        case 8: return objects8.count
+            //     "固定負債"
+        case 9: return objects9.count
+            //     "資本"
+        case 10: return objects10.count
+        case 11: return objects11.count
+        case 12: return objects12.count
+        case 13: return objects13.count
+        default: //    ""
+            return objects13.count
+        }
+    }
+    
+    func objects(forRow row: Int, section: Int) -> DataBaseSettingsTaxonomyAccount {
+        switch section {
+            //     "流動資産"
+        case 0: return objects0[row]
+        case 1: return objects1[row]
+        case 2: return objects2[row]
+            //     "固定資産"
+        case 3: return objects3[row]
+        case 4: return objects4[row]
+        case 5: return objects5[row]
+            //     "繰延資産"
+        case 6: return objects6[row]
+            //     "流動負債"
+        case 7: return objects7[row]
+        case 8: return objects8[row]
+            //     "固定負債"
+        case 9: return objects9[row]
+            //     "資本"
+        case 10: return objects10[row]
+        case 11: return objects11[row]
+        case 12: return objects12[row]
+        case 13: return objects13[row]
+        default: //    ""
+            return objects13[row]
+        }
+    }
+
     // 借方　残高　集計
     func debit_balance_total() -> String {
         

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/AfterClosingTrialBalancePresenter.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/AfterClosingTrialBalancePresenter.swift
@@ -51,6 +51,7 @@ final class AfterClosingTrialBalancePresenter: AfterClosingTrialBalancePresenter
     var theDayOfReckoning: String?
     // 設定勘定科目 貸借科目
     private var dataBaseSettingsTaxonomyAccounts: Results<DataBaseSettingsTaxonomyAccount>
+    
     private var objects0: Results<DataBaseSettingsTaxonomyAccount>
     private var objects1: Results<DataBaseSettingsTaxonomyAccount>
     private var objects2: Results<DataBaseSettingsTaxonomyAccount>

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/CategoryListPresenter.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/CategoryListPresenter.swift
@@ -14,8 +14,8 @@ protocol CategoryListPresenterInput {
     
 //    var dataBaseSettingsTaxonomyAccount: Results<DataBaseSettingsTaxonomyAccount> { get }
 
-    func numberOfobjects(section: Int) -> Int
     func numberOfsections() -> Int
+    func numberOfobjects(section: Int) -> Int
     func objects(forRow row: Int, section: Int) -> DataBaseSettingsTaxonomyAccount
     func titleForHeaderInSection(section: Int) -> String
 

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/CategoryListPresenter.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/CategoryListPresenter.swift
@@ -24,12 +24,14 @@ protocol CategoryListPresenterInput {
     
     func deleteSettingsTaxonomyAccount(indexPath: IndexPath)
     func changeSwitch(tag: Int, isOn: Bool)
+    func makeSerialNumbers(moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath)
 }
 
 protocol CategoryListPresenterOutput: AnyObject {
     func reloadData()
     func setupViewForViewDidLoad()
     func setupViewForViewWillAppear()
+    func showToast()
 }
 
 final class CategoryListPresenter: CategoryListPresenterInput {
@@ -377,7 +379,86 @@ final class CategoryListPresenter: CategoryListPresenterInput {
             return objects22[row]
         }
     }
-    
+
+    func objects(section: Int) -> Results<DataBaseSettingsTaxonomyAccount> {
+        
+        switch index {
+        case 0: //     "流動資産"
+            switch section {
+            case 0: return objects0
+            case 1: return objects1
+            case 2: return objects2
+            default: return objects2
+            }
+        case 1: //     "固定資産"
+            switch section {
+            case 0: return objects3
+            case 1: return objects4
+            case 2: return objects5
+            default: return objects5
+            }
+        case 2: //     "繰延資産"
+            switch section {
+            case 0: return objects6
+            default: return objects6
+            }
+        case 3: //     "流動負債"
+            switch section {
+            case 0: return objects7
+            case 1: return objects8
+            default: return objects8
+            }
+        case 4: //     "固定負債"
+            switch section {
+            case 0: return objects9
+            default: return objects9
+            }
+        case 5: //     "資本"
+            switch section {
+            case 0: return objects10
+            case 1: return objects11
+            case 2: return objects12
+            case 3: return objects13
+            default: return objects13
+            }
+        case 6: //     "売上"
+            switch section {
+            case 0: return objects14
+            default: return objects14
+            }
+        case 7: //     "売上原価"
+            switch section {
+            case 0: return objects15
+            case 1: return objects16
+            default: return objects16
+            }
+        case 8: //     "販売費及び一般管理費"
+            switch section {
+            case 0: return objects17
+            default: return objects17
+            }
+        case 9: //     "営業外損益"
+            switch section {
+            case 0: return objects18
+            case 1: return objects19
+            default: return objects19
+            }
+        case 10: //    "特別損益"
+            switch section {
+            case 0: return objects20
+            case 1: return objects21
+            default: return objects21
+            }
+        case 11: //    "税金"
+            switch section {
+            case 0: return objects22
+            default: return objects22
+            }
+        default: //    ""
+            return objects22
+        }
+    }
+
     func viewDidLoad() {
         
         view.setupViewForViewDidLoad()
@@ -405,5 +486,45 @@ final class CategoryListPresenter: CategoryListPresenterInput {
         model.updateSettingsCategorySwitching(tag: tag, isOn: isOn)
         // 表示科目のスイッチを設定する　勘定科目がひとつもなければOFFにする
         DataBaseManagerSettingsTaxonomy.shared.updateSettingsCategoryBSAndPLSwitching(number: tag)
+    }
+    
+    // 採番　設定勘定科目 並び替えの順序のためのシリアルナンバーを更新する
+    // カルーセルのタブの識別 移動前　移動後
+    func makeSerialNumbers(moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        // 入れ替え時の処理を実装する
+        if sourceIndexPath.section == destinationIndexPath.section {
+            // 移動前
+            let settingTaxonomies = objects(section: sourceIndexPath.section)
+            // 構造体に変換する
+            let objects = settingTaxonomies.map { object -> SeializingObject in
+                let number = object.number
+                let serialNumber = object.serialNumber
+                return SeializingObject(number: number, serialNumber: serialNumber)
+            }
+            print(objects)
+            // ソート
+            var sortedSettingTaxonomies = objects.sorted(by: { $0.serialNumber < $1.serialNumber })
+            print(sortedSettingTaxonomies)
+            // 順序を並び替える用
+            let offset = sourceIndexPath.row > destinationIndexPath.row ? destinationIndexPath.row : destinationIndexPath.row + 1
+            print(sourceIndexPath.row, destinationIndexPath.row)
+            print(offset)
+            // 並び替え
+            sortedSettingTaxonomies.move(fromOffsets: IndexSet([sourceIndexPath.row]), toOffset: offset)
+            print(sortedSettingTaxonomies)
+            // 採番　並び替えの順序のためのシリアルナンバーを更新する
+            DatabaseManagerSettingsTaxonomyAccount.shared.makeSerialNumbers(objects: sortedSettingTaxonomies)
+        } else {
+            view.showToast()
+        }
+    }
+}
+// 連番とシリアルナンバーを格納する構造体
+struct SeializingObject: CustomStringConvertible {
+    let number: Int
+    let serialNumber: Int
+
+    var description: String {
+        return "Object(number: \(number), serialNumber: \(serialNumber))"
     }
 }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/OpeningBalancePresenter.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/OpeningBalancePresenter.swift
@@ -11,24 +11,26 @@ import RealmSwift
 
 /// GUIアーキテクチャ　MVP
 protocol OpeningBalancePresenterInput {
-
+    
     var company: String? { get }
     var fiscalYear: Int? { get }
     var theDayOfBeginningOfYear: String? { get }
     var fiscalYearOpening: Int? { get }
-
-    var numberOfobjects: Int { get }
-
-    func objects(forRow row: Int) -> DataBaseSettingTransferEntry
-
+    
+    func objects(category: String) -> DataBaseSettingTransferEntry?
+    
+    func numberOfsections() -> Int
+    func numberOfobjects(section: Int) -> Int
+    func objects(forRow row: Int, section: Int) -> DataBaseSettingsTaxonomyAccount
+    
     func viewDidLoad()
     func viewWillAppear()
     func viewWillDisappear()
     func viewDidAppear()
-
+    
     func debit_balance_total() -> String
     func credit_balance_total() -> String
-
+    
     func setAmountValue(primaryKey: Int, numbersOnDisplay: Int, category: String, debitOrCredit: DebitOrCredit)
     func refreshTable()
 }
@@ -43,9 +45,9 @@ protocol OpeningBalancePresenterOutput: AnyObject {
 }
 
 final class OpeningBalancePresenter: OpeningBalancePresenterInput {
-
+    
     // MARK: - var let
-
+    
     var company: String?
     var fiscalYear: Int?
     var theDayOfBeginningOfYear: String?
@@ -53,10 +55,25 @@ final class OpeningBalancePresenter: OpeningBalancePresenterInput {
     var fiscalYearOpening: Int?
     // 設定残高振替仕訳 開始残高
     private var dataBaseTransferEntries: Results<DataBaseSettingTransferEntry>
-
+    // 設定勘定科目 貸借科目
+    private var objects0: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects1: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects2: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects3: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects4: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects5: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects6: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects7: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects8: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects9: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects10: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects11: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects12: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects13: Results<DataBaseSettingsTaxonomyAccount>
+    
     private weak var view: OpeningBalancePresenterOutput!
     private var model: OpeningBalanceModelInput
-
+    
     init(view: OpeningBalancePresenterOutput, model: OpeningBalanceModelInput) {
         self.view = view
         self.model = model
@@ -64,17 +81,37 @@ final class OpeningBalancePresenter: OpeningBalancePresenterInput {
         model.createOpeningBalance()
         // 設定残高振替仕訳 開始残高
         dataBaseTransferEntries = model.getDataBaseTransferEntries()
+        
+        objects0 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 0)
+        objects1 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 1)
+        objects2 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 2)
+        
+        objects3 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 3)
+        objects4 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 4)
+        objects5 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 5)
+        
+        objects6 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 2, rank1: 6)
+        
+        objects7 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 3, rank1: 7)
+        objects8 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 3, rank1: 8)
+        
+        objects9 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 4, rank1: 9)
+        
+        objects10 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 10)
+        objects11 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 11)
+        objects12 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 12)
+        objects13 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 19)
     }
-
+    
     // MARK: - Life cycle
-
+    
     func viewDidLoad() {
-
+        
         view.setupViewForViewDidLoad()
     }
-
+    
     func viewWillAppear() {
-
+        
         company = DataBaseManagerAccountingBooksShelf.shared.getCompanyName()
         // 一番古い会計帳簿の年度の期首　とする
         fiscalYear = DataBaseManagerSettingsPeriod.shared.getOldestPeriodYear()
@@ -83,28 +120,82 @@ final class OpeningBalancePresenter: OpeningBalancePresenterInput {
         fiscalYearOpening = DataBaseManagerSettingsPeriod.shared.getSettingsPeriodYear()
         // 再計算 合計額を計算
         model.calculateAccountTotalAccount()
-
+        
         view.setupViewForViewWillAppear()
     }
-
+    
     func viewWillDisappear() {
-
+        
         view.setupViewForViewWillDisappear()
     }
-
+    
     func viewDidAppear() {
-
+        
         view.setupViewForViewDidAppear()
     }
-
-    var numberOfobjects: Int {
-        dataBaseTransferEntries.count
+    
+    func objects(category: String) -> DataBaseSettingTransferEntry? {
+        dataBaseTransferEntries.filter({ $0.debit_category == category || $0.credit_category == category }).first
     }
-
-    func objects(forRow row: Int) -> DataBaseSettingTransferEntry {
-        dataBaseTransferEntries[row]
+    
+    func numberOfsections() -> Int {
+        14
     }
-
+    
+    func numberOfobjects(section: Int) -> Int {
+        switch section {
+            //     "流動資産"
+        case 0: return objects0.count
+        case 1: return objects1.count
+        case 2: return objects2.count
+            //     "固定資産"
+        case 3: return objects3.count
+        case 4: return objects4.count
+        case 5: return objects5.count
+            //     "繰延資産"
+        case 6: return objects6.count
+            //     "流動負債"
+        case 7: return objects7.count
+        case 8: return objects8.count
+            //     "固定負債"
+        case 9: return objects9.count
+            //     "資本"
+        case 10: return objects10.count
+        case 11: return objects11.count
+        case 12: return objects12.count
+        case 13: return objects13.count
+        default: //    ""
+            return objects13.count
+        }
+    }
+    
+    func objects(forRow row: Int, section: Int) -> DataBaseSettingsTaxonomyAccount {
+        switch section {
+            //     "流動資産"
+        case 0: return objects0[row]
+        case 1: return objects1[row]
+        case 2: return objects2[row]
+            //     "固定資産"
+        case 3: return objects3[row]
+        case 4: return objects4[row]
+        case 5: return objects5[row]
+            //     "繰延資産"
+        case 6: return objects6[row]
+            //     "流動負債"
+        case 7: return objects7[row]
+        case 8: return objects8[row]
+            //     "固定負債"
+        case 9: return objects9[row]
+            //     "資本"
+        case 10: return objects10[row]
+        case 11: return objects11[row]
+        case 12: return objects12[row]
+        case 13: return objects13[row]
+        default: //    ""
+            return objects13[row]
+        }
+    }
+    
     // 借方　残高　集計
     func debit_balance_total() -> String {
         StringUtility.shared.setComma(amount: model.getTotalAmount(leftOrRight: 0))
@@ -113,7 +204,7 @@ final class OpeningBalancePresenter: OpeningBalancePresenterInput {
     func credit_balance_total() -> String {
         StringUtility.shared.setComma(amount: model.getTotalAmount(leftOrRight: 1))
     }
-
+    
     func setAmountValue(primaryKey: Int, numbersOnDisplay: Int, category: String, debitOrCredit: DebitOrCredit) {
         model.setAmountValue(primaryKey: primaryKey, numbersOnDisplay: numbersOnDisplay, category: category, debitOrCredit: debitOrCredit)
         // 再計算 合計額を計算

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/SplashPresenter.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/SplashPresenter.swift
@@ -25,6 +25,8 @@ protocol SplashPresenterOutput: AnyObject {
     func finishActivityIndicatorView()
     // パーセンテージを表示させる
     func showPersentage(persentage: Int)
+    // パーセンテージを非表示させる
+    func hidePersentage()
     // 半強制アップデートダイアログを表示する アラートを表示し、App Store に誘導する
     func showForcedUpdateDialog()
     // AppStore
@@ -64,6 +66,8 @@ final class SplashPresenter: SplashPresenterInput {
                         // 半強制アップデートダイアログを表示する
                         self.view.showForcedUpdateDialog()
                     } else {
+                        // パーセンテージを非表示させる
+                        self.view.hidePersentage()
                         // インジケーターを終了
                         self.view.finishActivityIndicatorView()
                         // レビュー催促機能

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/TBPresenter.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/TBPresenter.swift
@@ -16,20 +16,20 @@ protocol TBPresenterInput {
     var fiscalYear: Int? { get }
     var theDayOfReckoning: String? { get }
     
-    var numberOfobjects: Int { get }
-
-    func objects(forRow row: Int) -> DataBaseSettingsTaxonomyAccount
-
+    func numberOfsections() -> Int
+    func numberOfobjects(section: Int) -> Int
+    func objects(forRow row: Int, section: Int) -> DataBaseSettingsTaxonomyAccount
+    
     func viewDidLoad()
     func viewWillAppear()
     func viewWillDisappear()
     func viewDidAppear()
-
+    
     func debit_total_total() -> String
     func credit_total_total() -> String
     func debit_balance_total() -> String
     func credit_balance_total() -> String
-        
+    
     func getTotalAmount(account: String, leftOrRight: Int) -> String
 }
 
@@ -41,14 +41,36 @@ protocol TBPresenterOutput: AnyObject {
 }
 
 final class TBPresenter: TBPresenterInput {
-
+    
     // MARK: - var let
     
     var company: String?
     var fiscalYear: Int?
     var theDayOfReckoning: String?
     // 設定勘定科目
-    private var objects: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects0: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects1: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects2: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects3: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects4: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects5: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects6: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects7: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects8: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects9: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects10: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects11: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects12: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects13: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects14: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects15: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects16: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects17: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects18: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects19: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects20: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects21: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects22: Results<DataBaseSettingsTaxonomyAccount>
     // 財務諸表
     private var object: DataBaseFinancialStatements
     
@@ -59,13 +81,46 @@ final class TBPresenter: TBPresenterInput {
         self.view = view
         self.model = model
         
-        objects = DatabaseManagerSettingsTaxonomyAccount.shared.getSettingsTaxonomyAccountAdjustingSwitch(adjustingAndClosingEntries: false, switching: true)
+        objects0 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 0)
+        objects1 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 1)
+        objects2 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 2)
+        
+        objects3 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 3)
+        objects4 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 4)
+        objects5 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 5)
+        
+        objects6 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 2, rank1: 6)
+        
+        objects7 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 3, rank1: 7)
+        objects8 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 3, rank1: 8)
+        
+        objects9 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 4, rank1: 9)
+        
+        objects10 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 10)
+        objects11 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 11)
+        objects12 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 12)
+        objects13 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 19)
+        
+        objects14 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 6, rank1: nil)
+        
+        objects15 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 7, rank1: 13)
+        objects16 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 7, rank1: 14)
+        
+        objects17 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 8, rank1: nil)
+        
+        objects18 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 9, rank1: 15)
+        objects19 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 9, rank1: 16)
+        
+        objects20 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 10, rank1: 17)
+        objects21 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 10, rank1: 18)
+        
+        objects22 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 11, rank1: nil)
         
         object = DataBaseManagerFinancialStatements.shared.getFinancialStatements()
     }
     
     // MARK: - Life cycle
-
+    
     func viewDidLoad() {
         
         view.setupViewForViewDidLoad()
@@ -81,23 +136,103 @@ final class TBPresenter: TBPresenterInput {
         
         view.setupViewForViewWillAppear()
     }
-
+    
     func viewWillDisappear() {
-
+        
         view.setupViewForViewWillDisappear()
     }
-
+    
     func viewDidAppear() {
         
         view.setupViewForViewDidAppear()
     }
     
-    var numberOfobjects: Int {
-        objects.count
+    func numberOfsections() -> Int {
+        23
     }
-
-    func objects(forRow row: Int) -> DataBaseSettingsTaxonomyAccount {
-        objects[row]
+    
+    func numberOfobjects(section: Int) -> Int {
+        switch section {
+            //     "流動資産"
+        case 0: return objects0.count
+        case 1: return objects1.count
+        case 2: return objects2.count
+            //     "固定資産"
+        case 3: return objects3.count
+        case 4: return objects4.count
+        case 5: return objects5.count
+            //     "繰延資産"
+        case 6: return objects6.count
+            //     "流動負債"
+        case 7: return objects7.count
+        case 8: return objects8.count
+            //     "固定負債"
+        case 9: return objects9.count
+            //     "資本"
+        case 10: return objects10.count
+        case 11: return objects11.count
+        case 12: return objects12.count
+        case 13: return objects13.count
+            //     "売上"
+        case 14: return objects14.count
+            //     "売上原価"
+        case 15: return objects15.count
+        case 16: return objects16.count
+            //     "販売費及び一般管理費"
+        case 17: return objects17.count
+            //     "営業外損益"
+        case 18: return objects18.count
+        case 19: return objects19.count
+            //    "特別損益"
+        case 20: return objects20.count
+        case 21: return objects21.count
+            //    "税金"
+        case 22: return objects22.count
+        default: //    ""
+            return objects22.count
+        }
+    }
+    
+    func objects(forRow row: Int, section: Int) -> DataBaseSettingsTaxonomyAccount {
+        switch section {
+            //     "流動資産"
+        case 0: return objects0[row]
+        case 1: return objects1[row]
+        case 2: return objects2[row]
+            //     "固定資産"
+        case 3: return objects3[row]
+        case 4: return objects4[row]
+        case 5: return objects5[row]
+            //     "繰延資産"
+        case 6: return objects6[row]
+            //     "流動負債"
+        case 7: return objects7[row]
+        case 8: return objects8[row]
+            //     "固定負債"
+        case 9: return objects9[row]
+            //     "資本"
+        case 10: return objects10[row]
+        case 11: return objects11[row]
+        case 12: return objects12[row]
+        case 13: return objects13[row]
+            //     "売上"
+        case 14: return objects14[row]
+            //     "売上原価"
+        case 15: return objects15[row]
+        case 16: return objects16[row]
+            //     "販売費及び一般管理費"
+        case 17: return objects17[row]
+            //     "営業外損益"
+        case 18: return objects18[row]
+        case 19: return objects19[row]
+            //    "特別損益"
+        case 20: return objects20[row]
+        case 21: return objects21[row]
+            //    "税金"
+        case 22: return objects22[row]
+        default: //    ""
+            return objects22[row]
+        }
     }
     
     // 借方　合計　集計
@@ -122,7 +257,7 @@ final class TBPresenter: TBPresenterInput {
     }
     // 取得　決算整理前　勘定クラス　合計、残高　勘定別の決算整理前の合計残高
     func getTotalAmount(account: String, leftOrRight: Int) -> String {
-
+        
         StringUtility.shared.setCommaForTB(amount: model.getTotalAmount(account: account, leftOrRight: leftOrRight))
     }
 }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/WSPresenter.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/WSPresenter.swift
@@ -16,11 +16,9 @@ protocol WSPresenterInput {
     var fiscalYear: Int? { get }
     var theDayOfReckoning: String? { get }
     
-    var numberOfobjects: Int { get }
-    var numberOfobjectss: Int { get }
-
-    func objects(forRow row: Int) -> DataBaseSettingsTaxonomyAccount
-    func objectss(forRow row: Int) -> DataBaseSettingsTaxonomyAccount
+    func numberOfsections() -> Int
+    func numberOfobjects(section: Int) -> Int
+    func objects(forRow row: Int, section: Int) -> DataBaseSettingsTaxonomyAccount
     
     func viewDidLoad()
     func viewWillAppear()
@@ -61,11 +59,30 @@ final class WSPresenter: WSPresenterInput {
     var company: String?
     var fiscalYear: Int?
     var theDayOfReckoning: String?
-    
-    // 期中の仕訳の勘定科目
-    private var objects: Results<DataBaseSettingsTaxonomyAccount>
-    // 修正記入の勘定科目
-    private var objectss: Results<DataBaseSettingsTaxonomyAccount>
+    // 設定勘定科目
+    private var objects0: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects1: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects2: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects3: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects4: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects5: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects6: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects7: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects8: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects9: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects10: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects11: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects12: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects13: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects14: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects15: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects16: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects17: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects18: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects19: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects20: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects21: Results<DataBaseSettingsTaxonomyAccount>
+    private var objects22: Results<DataBaseSettingsTaxonomyAccount>
     // 財務諸表
     private var object: DataBaseFinancialStatements
 
@@ -78,10 +95,42 @@ final class WSPresenter: WSPresenterInput {
 
         // 精算表　貸借対照表 損益計算書　初期化　再計算
         model.initialize()
-
-        objects = DatabaseManagerSettingsTaxonomyAccount.shared.getSettingsTaxonomyAccountAdjustingSwitch(adjustingAndClosingEntries: false, switching: true) // 期中の仕訳の勘定科目を取得
-        objectss = DatabaseManagerSettingsTaxonomyAccount.shared.getSettingsTaxonomyAccountAdjustingSwitch(adjustingAndClosingEntries: true, switching: true) // 修正記入の勘定科目を取得
         
+        objects0 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 0)
+        objects1 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 1)
+        objects2 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 0, rank1: 2)
+        
+        objects3 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 3)
+        objects4 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 4)
+        objects5 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 1, rank1: 5)
+        
+        objects6 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 2, rank1: 6)
+        
+        objects7 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 3, rank1: 7)
+        objects8 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 3, rank1: 8)
+        
+        objects9 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 4, rank1: 9)
+        
+        objects10 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 10)
+        objects11 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 11)
+        objects12 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 12)
+        objects13 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 5, rank1: 19)
+        
+        objects14 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 6, rank1: nil)
+        
+        objects15 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 7, rank1: 13)
+        objects16 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 7, rank1: 14)
+        
+        objects17 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 8, rank1: nil)
+        
+        objects18 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 9, rank1: 15)
+        objects19 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 9, rank1: 16)
+        
+        objects20 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 10, rank1: 17)
+        objects21 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 10, rank1: 18)
+        
+        objects22 = model.getDataBaseSettingsTaxonomyAccountInRank(rank0: 11, rank1: nil)
+
         object = DataBaseManagerFinancialStatements.shared.getFinancialStatements()
     }
     
@@ -110,23 +159,95 @@ final class WSPresenter: WSPresenterInput {
         
         view.setupViewForViewDidAppear()
     }
+        
+    func numberOfsections() -> Int {
+        23
+    }
     
-    var numberOfobjects: Int {
-        objects.count
+    func numberOfobjects(section: Int) -> Int {
+        switch section {
+            //     "流動資産"
+        case 0: return objects0.count
+        case 1: return objects1.count
+        case 2: return objects2.count
+            //     "固定資産"
+        case 3: return objects3.count
+        case 4: return objects4.count
+        case 5: return objects5.count
+            //     "繰延資産"
+        case 6: return objects6.count
+            //     "流動負債"
+        case 7: return objects7.count
+        case 8: return objects8.count
+            //     "固定負債"
+        case 9: return objects9.count
+            //     "資本"
+        case 10: return objects10.count
+        case 11: return objects11.count
+        case 12: return objects12.count
+        case 13: return objects13.count
+            //     "売上"
+        case 14: return objects14.count
+            //     "売上原価"
+        case 15: return objects15.count
+        case 16: return objects16.count
+            //     "販売費及び一般管理費"
+        case 17: return objects17.count
+            //     "営業外損益"
+        case 18: return objects18.count
+        case 19: return objects19.count
+            //    "特別損益"
+        case 20: return objects20.count
+        case 21: return objects21.count
+            //    "税金"
+        case 22: return objects22.count
+        default: //    ""
+            return objects22.count
+        }
+    }
+    
+    func objects(forRow row: Int, section: Int) -> DataBaseSettingsTaxonomyAccount {
+        switch section {
+            //     "流動資産"
+        case 0: return objects0[row]
+        case 1: return objects1[row]
+        case 2: return objects2[row]
+            //     "固定資産"
+        case 3: return objects3[row]
+        case 4: return objects4[row]
+        case 5: return objects5[row]
+            //     "繰延資産"
+        case 6: return objects6[row]
+            //     "流動負債"
+        case 7: return objects7[row]
+        case 8: return objects8[row]
+            //     "固定負債"
+        case 9: return objects9[row]
+            //     "資本"
+        case 10: return objects10[row]
+        case 11: return objects11[row]
+        case 12: return objects12[row]
+        case 13: return objects13[row]
+            //     "売上"
+        case 14: return objects14[row]
+            //     "売上原価"
+        case 15: return objects15[row]
+        case 16: return objects16[row]
+            //     "販売費及び一般管理費"
+        case 17: return objects17[row]
+            //     "営業外損益"
+        case 18: return objects18[row]
+        case 19: return objects19[row]
+            //    "特別損益"
+        case 20: return objects20[row]
+        case 21: return objects21[row]
+            //    "税金"
+        case 22: return objects22[row]
+        default: //    ""
+            return objects22[row]
+        }
     }
 
-    func objects(forRow row: Int) -> DataBaseSettingsTaxonomyAccount {
-        objects[row]
-    }
-    
-    var numberOfobjectss: Int {
-        objectss.count
-    }
-
-    func objectss(forRow row: Int) -> DataBaseSettingsTaxonomyAccount {
-        objectss[row]
-    }
-    
     func refreshTable() {
         // 精算表　貸借対照表 損益計算書　初期化　再計算
         model.initialize()

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/AccountDetailPickerTextField.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/AccountDetailPickerTextField.swift
@@ -74,7 +74,7 @@ class AccountDetailPickerTextField: UITextField, UIPickerViewDelegate, UIPickerV
 //        picker.transform = CGAffineTransform(scaleX: 0.5, y: 0.5);
         
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 0, height: 44))
-        toolbar.barTintColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.3) // RGBで指定する alpha 0透明　1不透明
+        //　toolbar.barTintColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.3) // RGBで指定する alpha 0透明　1不透明
         toolbar.isTranslucent = true
         toolbar.barStyle = .default
         let doneItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/AccountDetailPickerTextField.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/AccountDetailPickerTextField.swift
@@ -12,10 +12,10 @@ import UIKit
 class AccountDetailPickerTextField: UITextField, UIPickerViewDelegate, UIPickerViewDataSource {
 
     // 選択された項目
-    var selectedRank0 = ""
-    var selectedRank1 = ""
-    var accountDetailBig = ""
-    var accountDetail = ""
+    var selectedRank0 = "" // 大区分　row
+    var selectedRank1 = "" // 中区分　row
+    var accountDetailBig = "" // 大区分　名称
+    var accountDetail = "" // 中区分　名称
     // ドラムロールに表示する勘定科目の文言
     var big0: [String] = []
     var big1: [String] = []
@@ -48,6 +48,18 @@ class AccountDetailPickerTextField: UITextField, UIPickerViewDelegate, UIPickerV
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+    }
+    // 入力カーソル非表示
+    override func caretRect(for position: UITextPosition) -> CGRect {
+        CGRect.zero
+    }
+    // 範囲選択カーソル非表示
+    override func selectionRects(for range: UITextRange) -> [UITextSelectionRect] {
+        []
+    }
+    // コピー・ペースト・選択等のメニュー非表示
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        false
     }
     
     var identifier = ""
@@ -167,7 +179,7 @@ class AccountDetailPickerTextField: UITextField, UIPickerViewDelegate, UIPickerV
             case 11:
                 return big11.count
             default:
-                return 1
+                return 0
             }
         }
     }
@@ -406,11 +418,13 @@ class AccountDetailPickerTextField: UITextField, UIPickerViewDelegate, UIPickerV
 //        pickerView.reloadComponent(1)
     }
     // Buttonを押下　選択した値を仕訳画面のTextFieldに表示する
-    @objc func done() {
+    @objc 
+    func done() {
         self.endEditing(true)
     }
     
-    @objc func cancel() {
+    @objc 
+    func cancel() {
         accountDetailBig = ""
         accountDetail = ""
         self.selectedRank0 = ""

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingAccountDetailAccountTableViewCell.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingAccountDetailAccountTableViewCell.swift
@@ -10,83 +10,12 @@ import UIKit
 
 // 勘定科目詳細セル　テキストフィールド入力　勘定科目名
 class SettingAccountDetailAccountTableViewCell: UITableViewCell {
-
+    
     @IBOutlet var accountDetailAccountTextField: UITextField!
-
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
-        accountDetailAccountTextField.delegate = self
-        
-        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 0, height: 44))
-        //　toolbar.barTintColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.3) // RGBで指定する alpha 0透明　1不透明
-        toolbar.isTranslucent = true
-        toolbar.barStyle = .default
-        let doneItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
-        let flexSpaceItem = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
-        let cancelItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
-        toolbar.setItems([cancelItem, flexSpaceItem, doneItem], animated: true)
-        // previous, next, paste ボタンを消す
-        self.inputAssistantItem.leadingBarButtonGroups.removeAll()
-
-        self.accountDetailAccountTextField.inputAccessoryView = toolbar
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-    // Buttonを押下　選択した値を仕訳画面のTextFieldに表示する
-    @objc func done() {
-        self.endEditing(true)
     }
     
-    @objc func cancel() {
-        self.accountDetailAccountTextField.text = ""
-        self.endEditing(true)
-    }
-}
-
-extension SettingAccountDetailAccountTableViewCell: UITextFieldDelegate {
-
-    // textFieldに文字が入力される際に呼ばれる　入力チェック(文字列、文字数制限)
-    // 戻り値にtrueを返すと入力した文字がTextFieldに反映され、falseを返すと入力した文字が反映されない。
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        // 勘定科目名
-        guard textField == accountDetailAccountTextField else {
-            return false
-        }
-        // 文字列が0文字の場合、backspaceキーが押下されたということなので一文字削除する
-        guard !string.isEmpty else { // 入力された文字
-            textField.deleteBackward()
-            return true
-        }
-        // 入力チェック　カンマを除外
-        // 除外したい文字　(半角空白、全角空白)
-        let notAllowedCharacters = CharacterSet(charactersIn: ", 　") // Here change this characters based on your requirement
-        let characterSet = CharacterSet(charactersIn: string)
-        // 指定したスーパーセットの文字セットでないならfalseを返す
-        guard !(notAllowedCharacters.isSuperset(of: characterSet)) else { // 入力された文字
-            return false
-        }
-        // 入力チェック　文字数最大数を設定
-        let maxLength: Int = 20 // 文字数最大値を定義
-        // textField内の文字数
-        let textFieldTextCount = textField.text?.count ?? 0
-        // 入力された文字数
-        let stringCount = string.count
-        // 最大文字数以上ならfalseを返す
-        guard textFieldTextCount + stringCount <= maxLength else {
-            return false
-        }
-        // 判定
-        return true
-    }
-    // リターンキーが押されたとき
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        self.endEditing(true)
-
-        return false
-    }
 }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingAccountDetailAccountTableViewCell.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingAccountDetailAccountTableViewCell.swift
@@ -19,7 +19,7 @@ class SettingAccountDetailAccountTableViewCell: UITableViewCell {
         accountDetailAccountTextField.delegate = self
         
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 0, height: 44))
-        toolbar.barTintColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.3) // RGBで指定する alpha 0透明　1不透明
+        //　toolbar.barTintColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.3) // RGBで指定する alpha 0透明　1不透明
         toolbar.isTranslucent = true
         toolbar.barStyle = .default
         let doneItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
@@ -53,36 +53,35 @@ extension SettingAccountDetailAccountTableViewCell: UITextFieldDelegate {
     // textFieldに文字が入力される際に呼ばれる　入力チェック(文字列、文字数制限)
     // 戻り値にtrueを返すと入力した文字がTextFieldに反映され、falseを返すと入力した文字が反映されない。
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        var resultForCharacter = false
-        var resultForLength = false
-        // 入力チェック　カンマを除外
-        if textField == accountDetailAccountTextField { // 勘定科目名
-            // 除外したい文字　(半角空白、全角空白)
-            let notAllowedCharacters = CharacterSet(charactersIn: ", 　") // Here change this characters based on your requirement
-            let characterSet = CharacterSet(charactersIn: string)
-            // 指定したスーパーセットの文字セットでないならfalseを返す
-            resultForCharacter = !(notAllowedCharacters.isSuperset(of: characterSet))
-            // 入力チェック　文字数最大数を設定
-            let maxLength: Int = 20 // 文字数最大値を定義
-            // textField内の文字数
-            let textFieldNumber = textField.text?.count ?? 0    // todo
-            // 入力された文字数
-            let stringNumber = string.count
-            // 最大文字数以上ならfalseを返す
-            resultForLength = textFieldNumber + stringNumber < maxLength
-            // 文字列が0文字の場合、backspaceキーが押下されたということなので一文字削除する
-            if string.isEmpty {
-                textField.deleteBackward()
-            }
+        // 勘定科目名
+        guard textField == accountDetailAccountTextField else {
+            return false
         }
-        // 判定
-        if !resultForCharacter { // 指定したスーパーセットの文字セットならfalseを返す
-            return false
-        } else if !resultForLength { // 最大文字数以上ならfalseを返す
-            return false
-        } else {
+        // 文字列が0文字の場合、backspaceキーが押下されたということなので一文字削除する
+        guard !string.isEmpty else { // 入力された文字
+            textField.deleteBackward()
             return true
         }
+        // 入力チェック　カンマを除外
+        // 除外したい文字　(半角空白、全角空白)
+        let notAllowedCharacters = CharacterSet(charactersIn: ", 　") // Here change this characters based on your requirement
+        let characterSet = CharacterSet(charactersIn: string)
+        // 指定したスーパーセットの文字セットでないならfalseを返す
+        guard !(notAllowedCharacters.isSuperset(of: characterSet)) else { // 入力された文字
+            return false
+        }
+        // 入力チェック　文字数最大数を設定
+        let maxLength: Int = 20 // 文字数最大値を定義
+        // textField内の文字数
+        let textFieldTextCount = textField.text?.count ?? 0
+        // 入力された文字数
+        let stringCount = string.count
+        // 最大文字数以上ならfalseを返す
+        guard textFieldTextCount + stringCount <= maxLength else {
+            return false
+        }
+        // 判定
+        return true
     }
     // リターンキーが押されたとき
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingAccountDetailTableViewCell.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingAccountDetailTableViewCell.swift
@@ -8,22 +8,163 @@
 
 import UIKit
 
-// 勘定科目詳細セル　テキストフィールド入力　大区分　中区分　小区分
-class SettingAccountDetailTableViewCell: UITableViewCell, UITextFieldDelegate {
+protocol TableViewCellDelegate {
+    func selectedRankAction(big: String, mid: String, bigNum: String, midNum: String)
+    func selectedAccountAction(accountname: String?)
+}
+// 勘定科目詳細セル　大区分　中区分 勘定科目名 表示科目名
+class SettingAccountDetailTableViewCell: UITableViewCell {
     
     @IBOutlet var accountDetailBigTextField: AccountDetailPickerTextField!
-//    @IBOutlet var textField_AccountDetail: AccountDetailPickerTextField!
+    @IBOutlet var accountDetailAccountTextField: UITextField!
+    @IBOutlet var label: UILabel!
+    
+    var delegate: TableViewCellDelegate?
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
-        // テキストフィールド作成
-        self.accountDetailBigTextField.inputAssistantItem.leadingBarButtonGroups.removeAll()
+        // 大区分　中区分
+        if let accountDetailBigTextField = accountDetailBigTextField {
+            accountDetailBigTextField.delegate = self
+            accountDetailBigTextField.inputAssistantItem.leadingBarButtonGroups.removeAll()
+            // TextFieldに入力された値に反応
+            accountDetailBigTextField.addTarget(self, action: #selector(textFieldEditingDidEnd), for: UIControl.Event.editingDidEnd)
+            accountDetailBigTextField.addTarget(self, action: #selector(textFieldEditingDidEnd), for: UIControl.Event.editingDidEnd)
+        }
+        // 勘定科目名
+        if let accountDetailAccountTextField = accountDetailAccountTextField {
+            accountDetailAccountTextField.delegate = self
+            let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 0, height: 44))
+            //　toolbar.barTintColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.3) // RGBで指定する alpha 0透明　1不透明
+            toolbar.isTranslucent = true
+            toolbar.barStyle = .default
+            let doneItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
+            let flexSpaceItem = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+            let cancelItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
+            toolbar.setItems([cancelItem, flexSpaceItem, doneItem], animated: true)
+            // previous, next, paste ボタンを消す
+            self.inputAssistantItem.leadingBarButtonGroups.removeAll()
+            accountDetailAccountTextField.inputAccessoryView = toolbar
+            // 入力開始
+            accountDetailAccountTextField.addTarget(self, action: #selector(textFieldEditingDidBegin),for: UIControl.Event.editingDidBegin)
+            // 入力終了
+            accountDetailAccountTextField.addTarget(self, action: #selector(textFieldEditingDidEnd), for: UIControl.Event.editingDidEnd)
+        }
     }
-
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // 大区分　中区分
+        if let accountDetailBigTextField = accountDetailBigTextField {
+            accountDetailBigTextField.isHidden = true
+        }
+        // 勘定科目名
+        if let accountDetailAccountTextField = accountDetailAccountTextField {
+            accountDetailAccountTextField.isHidden = true
+        }
+        // 表示科目
+        if let label = label {
+            label.text = ""
+            label.isHidden = true
+        }
+        accessoryType = .none
+        // セルの選択
+        selectionStyle = .none
+        accessoryView = nil
+    }
+    
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
+        
         // Configure the view for the selected state
+    }
+    
+    // Buttonを押下　選択した値を仕訳画面のTextFieldに表示する
+    @objc
+    func done() {
+        self.endEditing(true)
+    }
+    
+    @objc
+    func cancel() {
+        // 勘定科目名
+        if let accountDetailAccountTextField = accountDetailAccountTextField {
+            accountDetailAccountTextField.text = ""
+        }
+        self.endEditing(true)
+    }
+}
+
+extension SettingAccountDetailTableViewCell: UITextFieldDelegate {
+    
+    // textFieldに文字が入力される際に呼ばれる　入力チェック(文字列、文字数制限)
+    // 戻り値にtrueを返すと入力した文字がTextFieldに反映され、falseを返すと入力した文字が反映されない。
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        // 勘定科目名
+        guard textField == accountDetailAccountTextField else {
+            return false
+        }
+        // 文字列が0文字の場合、backspaceキーが押下されたということなので一文字削除する
+        guard !string.isEmpty else { // 入力された文字
+            //　textField.deleteBackward()　2文字分を削除してしまう
+            return true // true だと2文字分を削除してしまう false だと未確定の文字が消えない
+        }
+        // 入力チェック　カンマを除外
+        // 除外したい文字　(半角空白、全角空白)
+        let notAllowedCharacters = CharacterSet(charactersIn: ", 　") // Here change this characters based on your requirement
+        let characterSet = CharacterSet(charactersIn: string)
+        // 指定したスーパーセットの文字セットでないならfalseを返す
+        guard !(notAllowedCharacters.isSuperset(of: characterSet)) else { // 入力された文字
+            return false
+        }
+        // 入力チェック　文字数最大数を設定
+        let maxLength: Int = 20 // 文字数最大値を定義
+        // textField内の文字数
+        let textFieldTextCount = textField.text?.count ?? 0
+        // 入力された文字数
+        let stringCount = string.count
+        // 最大文字数以上ならfalseを返す
+        guard textFieldTextCount + stringCount <= maxLength else {
+            return false
+        }
+        // 判定
+        return true
+    }
+    // 入力開始 テキストフィールがタップされ、入力可能になったあと
+    @objc
+    func textFieldEditingDidBegin(_ textField: UITextField) {
+        // フォーカス　効果　ドロップシャドウをかける
+        textField.layer.shadowOpacity = 1.4
+        textField.layer.shadowRadius = 4
+        textField.layer.shadowColor = UIColor.calculatorDisplay.cgColor
+        textField.layer.shadowOffset = CGSize(width: 0.0, height: 1.0)
+    }
+    // 入力終了 テキストフィールへの入力が終了したとき
+    @objc
+    func textFieldEditingDidEnd(_ textField: UITextField) {
+        // フォーカス　効果　フォーカスが外れたら色を消す
+        textField.layer.shadowColor = UIColor.clear.cgColor
+        // 取得　TextField 入力テキスト
+        
+        // 勘定科目区分選択　の場合
+        if textField is AccountDetailPickerTextField {
+            // 大区分
+            // 中区分
+            delegate?.selectedRankAction(
+                big: accountDetailBigTextField.accountDetailBig,
+                mid: accountDetailBigTextField.accountDetail,
+                bigNum: accountDetailBigTextField.selectedRank0,
+                midNum: accountDetailBigTextField.selectedRank1
+            )
+        }
+        // 勘定科目名
+        delegate?.selectedAccountAction(accountname: accountDetailAccountTextField?.text)
+    }
+    
+    // リターンキーが押されたとき
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        self.endEditing(true)
+        
+        return false
     }
 }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingsCategoryDetailTableViewController.storyboard
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingsCategoryDetailTableViewController.storyboard
@@ -17,17 +17,18 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" name="BaseColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="atH-Tk-ti9">
-                            <rect key="frame" x="0.0" y="249.5" width="414" height="120"/>
+                            <rect key="frame" x="0.0" y="117.5" width="414" height="120"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="htm-3x-yix" customClass="EMTNeumorphicButton" customModule="EMTNeumorphicView">
+                                <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" adjustsImageSizeForAccessibilityContentSizeCategory="YES" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="htm-3x-yix" customClass="EMTNeumorphicButton" customModule="EMTNeumorphicView">
                                     <rect key="frame" x="117.5" y="30" width="179" height="60"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="60" id="Lu3-M3-15R"/>
                                     </constraints>
-                                    <fontDescription key="fontDescription" name="HiraginoSans-W3" family="Hiragino Sans" pointSize="24"/>
-                                    <state key="normal" title="登録">
+                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                    <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <state key="normal">
                                         <color key="titleColor" name="ButtonTextColor"/>
                                     </state>
                                     <userDefinedRuntimeAttributes>
@@ -48,111 +49,52 @@
                             </constraints>
                         </view>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="identifier_category_big" id="LBG-EM-5r1" customClass="SettingAccountDetailTableViewCell" customModule="Paciolist" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="reuseIdentifier" rowHeight="44" id="0KT-tB-STM" customClass="SettingAccountDetailTableViewCell" customModule="Paciolist" customModuleProvider="target">
                                 <rect key="frame" x="20" y="55.5" width="374" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LBG-EM-5r1" id="qGA-GO-u7y">
-                                    <rect key="frame" x="0.0" y="0.0" width="374" height="44"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="選択してください" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="4Cm-FI-Chr" customClass="AccountDetailPickerTextField" customModule="Paciolist" customModuleProvider="target">
-                                            <rect key="frame" x="115" y="5" width="181" height="34"/>
-                                            <color key="backgroundColor" name="MainColor2"/>
-                                            <color key="textColor" name="TextColor"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <textInputTraits key="textInputTraits"/>
-                                        </textField>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstItem="4Cm-FI-Chr" firstAttribute="centerX" secondItem="qGA-GO-u7y" secondAttribute="centerX" multiplier="1.1" id="2vY-IU-lvd"/>
-                                        <constraint firstItem="4Cm-FI-Chr" firstAttribute="width" secondItem="qGA-GO-u7y" secondAttribute="width" multiplier="0.483957" id="BsM-X5-anv"/>
-                                        <constraint firstItem="4Cm-FI-Chr" firstAttribute="centerY" secondItem="qGA-GO-u7y" secondAttribute="centerY" id="QUE-P4-OfD"/>
-                                        <constraint firstItem="4Cm-FI-Chr" firstAttribute="height" secondItem="qGA-GO-u7y" secondAttribute="height" multiplier="0.781609" id="jeE-Pe-jIc"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                                <color key="backgroundColor" name="MainColor2"/>
-                                <connections>
-                                    <outlet property="accountDetailBigTextField" destination="4Cm-FI-Chr" id="tAG-oH-RUH"/>
-                                </connections>
-                            </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="identifier_category" id="7R0-uJ-Cbn" customClass="SettingAccountDetailTableViewCell" customModule="Paciolist" customModuleProvider="target">
-                                <rect key="frame" x="20" y="99.5" width="374" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7R0-uJ-Cbn" id="hJa-cr-wfc">
-                                    <rect key="frame" x="0.0" y="0.0" width="374" height="44"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="選択してください" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="Iv9-Ab-XG0" customClass="AccountDetailPickerTextField" customModule="Paciolist" customModuleProvider="target">
-                                            <rect key="frame" x="115" y="5" width="181" height="34"/>
-                                            <color key="backgroundColor" name="MainColor2"/>
-                                            <color key="textColor" name="TextColor"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <textInputTraits key="textInputTraits"/>
-                                        </textField>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstItem="Iv9-Ab-XG0" firstAttribute="centerX" secondItem="hJa-cr-wfc" secondAttribute="centerX" multiplier="1.1" id="00q-YA-eVC"/>
-                                        <constraint firstItem="Iv9-Ab-XG0" firstAttribute="width" secondItem="hJa-cr-wfc" secondAttribute="width" multiplier="0.483957" id="Yyh-63-BVg"/>
-                                        <constraint firstItem="Iv9-Ab-XG0" firstAttribute="centerY" secondItem="hJa-cr-wfc" secondAttribute="centerY" id="aki-7i-Fxm"/>
-                                        <constraint firstItem="Iv9-Ab-XG0" firstAttribute="height" secondItem="hJa-cr-wfc" secondAttribute="height" multiplier="0.781609" id="shb-Da-uiL"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                                <color key="backgroundColor" name="MainColor2"/>
-                                <connections>
-                                    <outlet property="textField_AccountDetail" destination="Iv9-Ab-XG0" id="rwd-Pg-ucx"/>
-                                </connections>
-                            </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="identifier_Account" id="QPs-Yn-bhd" customClass="SettingAccountDetailAccountTableViewCell" customModule="Paciolist" customModuleProvider="target">
-                                <rect key="frame" x="20" y="143.5" width="374" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QPs-Yn-bhd" id="VE0-w9-hmH">
-                                    <rect key="frame" x="0.0" y="0.0" width="374" height="44"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="入力してください" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="3XR-6k-myl">
-                                            <rect key="frame" x="115" y="5" width="181" height="34"/>
-                                            <color key="backgroundColor" name="MainColor2"/>
-                                            <color key="textColor" name="TextColor"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <textInputTraits key="textInputTraits"/>
-                                        </textField>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstItem="3XR-6k-myl" firstAttribute="width" secondItem="VE0-w9-hmH" secondAttribute="width" multiplier="0.483957" id="FXS-um-T6K"/>
-                                        <constraint firstItem="3XR-6k-myl" firstAttribute="centerX" secondItem="VE0-w9-hmH" secondAttribute="centerX" multiplier="1.1" id="WOR-pu-Tnd"/>
-                                        <constraint firstItem="3XR-6k-myl" firstAttribute="centerY" secondItem="VE0-w9-hmH" secondAttribute="centerY" id="bJL-Lp-BWT"/>
-                                        <constraint firstItem="3XR-6k-myl" firstAttribute="height" secondItem="VE0-w9-hmH" secondAttribute="height" multiplier="0.781609" id="fVU-yJ-9H4"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                                <color key="backgroundColor" name="MainColor2"/>
-                                <connections>
-                                    <outlet property="accountDetailAccountTextField" destination="3XR-6k-myl" id="pAj-5O-p8o"/>
-                                </connections>
-                            </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="reuseIdentifier" rowHeight="44" id="0KT-tB-STM" customClass="SettingAccountDetailTaxonomyTableViewCell" customModule="Paciolist" customModuleProvider="target">
-                                <rect key="frame" x="20" y="187.5" width="374" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0KT-tB-STM" id="dBs-Vr-npS">
                                     <rect key="frame" x="0.0" y="0.0" width="343.5" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="選択してください" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="4Cm-FI-Chr" customClass="AccountDetailPickerTextField" customModule="Paciolist" customModuleProvider="target">
+                                            <rect key="frame" x="100" y="5" width="223.5" height="34"/>
+                                            <color key="backgroundColor" name="MainColor2"/>
+                                            <color key="textColor" name="TextColor"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="入力してください" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="3XR-6k-myl">
+                                            <rect key="frame" x="100" y="5" width="223.5" height="34"/>
+                                            <color key="backgroundColor" name="MainColor2"/>
+                                            <color key="textColor" name="TextColor"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zbZ-zd-LJt" userLabel="label">
-                                            <rect key="frame" x="103" y="5" width="206" height="34"/>
+                                            <rect key="frame" x="100" y="5" width="223.5" height="34"/>
                                             <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="13"/>
                                             <color key="textColor" name="TextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="zbZ-zd-LJt" firstAttribute="centerX" secondItem="dBs-Vr-npS" secondAttribute="centerX" multiplier="1.2" id="4bg-8E-Tpt"/>
-                                        <constraint firstItem="zbZ-zd-LJt" firstAttribute="width" secondItem="dBs-Vr-npS" secondAttribute="width" multiplier="0.6" id="Ubc-o5-b1k"/>
+                                        <constraint firstItem="4Cm-FI-Chr" firstAttribute="centerY" secondItem="dBs-Vr-npS" secondAttribute="centerY" id="26k-YP-CtT"/>
+                                        <constraint firstAttribute="trailing" secondItem="3XR-6k-myl" secondAttribute="trailing" constant="20" id="9Wa-fR-AbE"/>
+                                        <constraint firstAttribute="trailing" secondItem="zbZ-zd-LJt" secondAttribute="trailing" constant="20" id="UBh-dh-WmL"/>
+                                        <constraint firstItem="zbZ-zd-LJt" firstAttribute="width" secondItem="dBs-Vr-npS" secondAttribute="width" multiplier="0.65" id="Ubc-o5-b1k"/>
+                                        <constraint firstItem="3XR-6k-myl" firstAttribute="width" secondItem="dBs-Vr-npS" secondAttribute="width" multiplier="0.65" id="ZD0-fu-VIq"/>
                                         <constraint firstItem="zbZ-zd-LJt" firstAttribute="height" secondItem="dBs-Vr-npS" secondAttribute="height" multiplier="0.781609" id="bkQ-uK-Giv"/>
+                                        <constraint firstAttribute="trailing" secondItem="4Cm-FI-Chr" secondAttribute="trailing" constant="20" id="bz2-AJ-A2F"/>
                                         <constraint firstItem="zbZ-zd-LJt" firstAttribute="centerY" secondItem="dBs-Vr-npS" secondAttribute="centerY" id="eeh-ey-xAs"/>
+                                        <constraint firstItem="3XR-6k-myl" firstAttribute="centerY" secondItem="dBs-Vr-npS" secondAttribute="centerY" id="hAP-Ls-iyr"/>
+                                        <constraint firstItem="4Cm-FI-Chr" firstAttribute="width" secondItem="dBs-Vr-npS" secondAttribute="width" multiplier="0.65" id="tU4-gQ-Pq8"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <color key="backgroundColor" name="MainColor2"/>
                                 <connections>
-                                    <outlet property="label" destination="zbZ-zd-LJt" id="hyL-NH-UK9"/>
+                                    <outlet property="accountDetailAccountTextField" destination="3XR-6k-myl" id="oMi-Ym-fxp"/>
+                                    <outlet property="accountDetailBigTextField" destination="4Cm-FI-Chr" id="ACN-ef-OcC"/>
+                                    <outlet property="label" destination="zbZ-zd-LJt" id="PHd-xQ-nfy"/>
                                     <segue destination="B4C-gl-Hho" kind="presentation" identifier="segue_TaxonomyList" id="IAu-Lh-II4"/>
                                 </connections>
                             </tableViewCell>
@@ -182,7 +124,7 @@
     </scenes>
     <resources>
         <namedColor name="BaseColor">
-            <color red="0.87800002098083496" green="0.89800000190734863" blue="0.92500001192092896" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.8784313725490196" green="0.89803921568627454" blue="0.92549019607843142" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="ButtonTextColor">
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingsCategoryDetailTableViewController.storyboard
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingsCategoryDetailTableViewController.storyboard
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cje-Si-hva">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cje-Si-hva">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--勘定科目　詳細-->
+        <!--勘定科目詳細-->
         <scene sceneID="ajk-NH-7Qn">
             <objects>
                 <tableViewController id="cje-Si-hva" customClass="SettingsCategoryDetailTableViewController" customModule="Paciolist" customModuleProvider="target" sceneMemberID="viewController">
@@ -17,11 +17,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" name="BaseColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="atH-Tk-ti9">
-                            <rect key="frame" x="0.0" y="243.5" width="414" height="120"/>
+                            <rect key="frame" x="0.0" y="249.5" width="414" height="120"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="htm-3x-yix" customClass="EMTNeumorphicButton" customModule="EMTNeumorphicView">
-                                    <rect key="frame" x="118" y="30" width="179" height="60"/>
+                                    <rect key="frame" x="117.5" y="30" width="179" height="60"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="60" id="Lu3-M3-15R"/>
@@ -49,7 +49,7 @@
                         </view>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="identifier_category_big" id="LBG-EM-5r1" customClass="SettingAccountDetailTableViewCell" customModule="Paciolist" customModuleProvider="target">
-                                <rect key="frame" x="20" y="49.5" width="374" height="44"/>
+                                <rect key="frame" x="20" y="55.5" width="374" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LBG-EM-5r1" id="qGA-GO-u7y">
                                     <rect key="frame" x="0.0" y="0.0" width="374" height="44"/>
@@ -76,7 +76,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="identifier_category" id="7R0-uJ-Cbn" customClass="SettingAccountDetailTableViewCell" customModule="Paciolist" customModuleProvider="target">
-                                <rect key="frame" x="20" y="93.5" width="374" height="44"/>
+                                <rect key="frame" x="20" y="99.5" width="374" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7R0-uJ-Cbn" id="hJa-cr-wfc">
                                     <rect key="frame" x="0.0" y="0.0" width="374" height="44"/>
@@ -103,7 +103,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="identifier_Account" id="QPs-Yn-bhd" customClass="SettingAccountDetailAccountTableViewCell" customModule="Paciolist" customModuleProvider="target">
-                                <rect key="frame" x="20" y="137.5" width="374" height="44"/>
+                                <rect key="frame" x="20" y="143.5" width="374" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QPs-Yn-bhd" id="VE0-w9-hmH">
                                     <rect key="frame" x="0.0" y="0.0" width="374" height="44"/>
@@ -130,14 +130,14 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="reuseIdentifier" rowHeight="44" id="0KT-tB-STM" customClass="SettingAccountDetailTaxonomyTableViewCell" customModule="Paciolist" customModuleProvider="target">
-                                <rect key="frame" x="20" y="181.5" width="374" height="44"/>
+                                <rect key="frame" x="20" y="187.5" width="374" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0KT-tB-STM" id="dBs-Vr-npS">
-                                    <rect key="frame" x="0.0" y="0.0" width="345.5" height="44"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="343.5" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zbZ-zd-LJt" userLabel="label">
-                                            <rect key="frame" x="103.5" y="5" width="207.5" height="34"/>
+                                            <rect key="frame" x="103" y="5" width="206" height="34"/>
                                             <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="13"/>
                                             <color key="textColor" name="TextColor"/>
                                             <nil key="highlightedColor"/>
@@ -162,7 +162,7 @@
                             <outlet property="delegate" destination="cje-Si-hva" id="MD3-OJ-7F3"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="勘定科目　詳細" id="ijy-fE-kMc"/>
+                    <navigationItem key="navigationItem" title="勘定科目詳細" id="ijy-fE-kMc"/>
                     <connections>
                         <outlet property="inputButton" destination="htm-3x-yix" id="hLV-us-j1F"/>
                     </connections>
@@ -182,13 +182,13 @@
     </scenes>
     <resources>
         <namedColor name="BaseColor">
-            <color red="0.8784313725490196" green="0.89803921568627454" blue="0.92549019607843142" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.87800002098083496" green="0.89800000190734863" blue="0.92500001192092896" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="ButtonTextColor">
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="MainColor2">
-            <color red="0.96862745098039216" green="0.96470588235294119" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+            <color red="0.96899998188018799" green="0.9649999737739563" blue="0.96100002527236938" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
         <namedColor name="TextColor">
             <color red="0.05000000074505806" green="0.05000000074505806" blue="0.05000000074505806" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingsCategoryDetailTableViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryDetail/SettingsCategoryDetailTableViewController.swift
@@ -364,7 +364,8 @@ class SettingsCategoryDetailTableViewController: UITableViewController {
         categoryCell.accountDetailAccountTextField.addTarget(self, action: #selector(textFieldEditingDidEnd), for: UIControl.Event.editingDidEnd)
     }
     // テキストフィールへの入力が終了したとき
-    @objc func textFieldEditingDidEnd(_ textField: UITextField) {
+    @objc 
+    func textFieldEditingDidEnd(_ textField: UITextField) {
         // 取得　TextField 入力テキスト
         
         // 勘定科目区分選択　の場合

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListCarouselAndPageViewController.storyboard
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListCarouselAndPageViewController.storyboard
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qWJ-fX-ARW">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qWJ-fX-ARW">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YKG-Wt-OaB">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="59" width="414" height="44"/>
                                 <subviews>
                                     <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="oNy-pg-jSr">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -42,7 +44,7 @@
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aH1-ua-LeE">
-                                <rect key="frame" x="0.0" y="44" width="414" height="803"/>
+                                <rect key="frame" x="0.0" y="103" width="414" height="710"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <segue destination="43I-6N-3lI" kind="embed" id="f3f-QX-3NS"/>
@@ -67,11 +69,7 @@
                     <toolbarItems/>
                     <navigationItem key="navigationItem" title="勘定科目一覧" id="NFT-2f-UH9">
                         <rightBarButtonItems>
-                            <barButtonItem systemItem="edit" id="avs-VZ-7NF">
-                                <connections>
-                                    <action selector="editButtonTapped:" destination="qWJ-fX-ARW" id="X8w-5k-6Ei"/>
-                                </connections>
-                            </barButtonItem>
+                            <barButtonItem systemItem="edit" id="avs-VZ-7NF"/>
                             <barButtonItem systemItem="add" id="xU2-W2-fCt">
                                 <connections>
                                     <segue destination="wUu-3j-g8E" kind="presentation" identifier="segue_add_account" id="8ws-jh-2AV"/>
@@ -112,7 +110,7 @@
     </scenes>
     <resources>
         <namedColor name="BaseColor">
-            <color red="0.8784313725490196" green="0.89803921568627454" blue="0.92549019607843142" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.87800002098083496" green="0.89800000190734863" blue="0.92500001192092896" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListCarouselAndPageViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListCarouselAndPageViewController.swift
@@ -20,6 +20,9 @@ class CategoryListCarouselAndPageViewController: CarouselAndPageViewController {
         // タブに表示する文言
         pageTabItems = Rank0.allCases.map({ $0.rawValue })
         super.viewDidLoad()
+        
+        // 編集ボタンの設定
+        navigationItem.rightBarButtonItem = editButtonItem
     }
     
     // MARK: - Action
@@ -32,6 +35,8 @@ class CategoryListCarouselAndPageViewController: CarouselAndPageViewController {
             pageViewController.setViewControllers([viewController], direction: .forward, animated: false, completion: nil)
             // セルを選択して、collectionViewの中の中心にスクロールさせる　追随　追従
             self.carouselCollectionView.selectItem(at: IndexPath(row: selectedIndex, section: 0), animated: true, scrollPosition: .centeredHorizontally)
+            // 編集モードを切り替える
+            viewController.setEditing(isEditing, animated: false)
         }
     }
     // 画面遷移の準備　勘定科目画面
@@ -45,11 +50,13 @@ class CategoryListCarouselAndPageViewController: CarouselAndPageViewController {
             }
         }
     }
-
-    @IBAction func editButtonTapped(_ sender: Any) {
+    
+    // 編集モード切り替え
+    override func setEditing(_ editing: Bool, animated: Bool) {
+        super.setEditing(editing, animated: animated)
         // 編集モードを切り替える
         if let currentVC = pageViewController.viewControllers?.first as? CategoryListTableViewController {
-            currentVC.setEditing(!currentVC.isEditing, animated: true)
+            currentVC.setEditing(editing, animated: true)
         }
     }
     
@@ -93,7 +100,8 @@ class CategoryListCarouselAndPageViewController: CarouselAndPageViewController {
             // タブの選択位置を更新する
             // セルを選択して、コレクションビューの中の中心へスクロールさせる
             self.carouselCollectionView.selectItem(at: IndexPath(row: selectedIndex, section: 0), animated: true, scrollPosition: .centeredHorizontally)
-
+            // 編集モードを切り替える
+            currentVC.setEditing(isEditing, animated: false)
         }
     }
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListTableViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListTableViewController.swift
@@ -9,7 +9,7 @@
 import AudioToolbox // 効果音
 import UIKit
 
-// 勘定科目一覧　画面
+// 設定勘定科目一覧　画面
 class CategoryListTableViewController: UITableViewController {
     
     // MARK: - Variable/Let
@@ -138,6 +138,8 @@ class CategoryListTableViewController: UITableViewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             self.tableView.reloadData()
         }
+        // 並び替え　ドラッグ&ドロップ
+        tableView.allowsSelectionDuringEditing = false
     }
     
     // MARK: - Navigation
@@ -318,6 +320,18 @@ class CategoryListTableViewController: UITableViewController {
             tableView.endUpdates()
         }
     }
+    
+    // 並び替え　ドラッグ&ドロップ
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        true
+    }
+    // 並び替え　ドラッグ&ドロップ
+    override func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        
+        // 採番　設定勘定科目 並び替えの順序のためのシリアルナンバーを更新する
+        presenter.makeSerialNumbers(moveRowAt: sourceIndexPath, to: destinationIndexPath)
+    }
+    
     // 編集機能
     override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         // デフォルトの勘定科目数（230）以上ある場合は、削除可能とし、それ以下の場合は削除不可とする。
@@ -342,6 +356,10 @@ class CategoryListTableViewController: UITableViewController {
         }
         return .delete
     }
+    // インデント
+    override func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+        true
+    }
 }
 
 extension CategoryListTableViewController: CategoryListPresenterOutput {
@@ -359,5 +377,13 @@ extension CategoryListTableViewController: CategoryListPresenterOutput {
     func setupViewForViewWillAppear() {
         // 勘定科目画面から、仕訳帳画面へ遷移して仕訳を追加した後に、戻ってきた場合はリロードする
         tableView.reloadData()
+    }
+    
+    func showToast() {
+        Toast.show("並び替えは同じ中区分内でのみ可能です", self.tableView)
+        // 別のセクションへ移動しようとした場合
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            self.tableView.reloadData()
+        }
     }
 }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListTableViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListTableViewController.swift
@@ -135,6 +135,9 @@ class CategoryListTableViewController: UITableViewController {
         super.setEditing(editing, animated: animated)
         
         tableView.setEditing(editing, animated: animated)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            self.tableView.reloadData()
+        }
     }
     
     // MARK: - Navigation
@@ -174,6 +177,16 @@ class CategoryListTableViewController: UITableViewController {
         
         presenter.numberOfobjects(section: section)
     }
+    
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        // 編集モードの場合
+        if tableView.isEditing {
+            return 43.5
+        } else {
+            // 勘定科目の有効無効
+            return presenter.objects(forRow: indexPath.row, section: indexPath.section).switching ? 43.5 : 0
+        }
+    }
     // セルを生成して返却するメソッド
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         // ① UI部品を指定　TableViewCellCategory
@@ -211,31 +224,39 @@ class CategoryListTableViewController: UITableViewController {
             //                }
             //            }
         }
-        // 勘定科目の有効無効
-        cell.toggleButton.isOn = presenter.objects(forRow: indexPath.row, section: indexPath.section).switching
-        // 勘定科目の有効無効　変更時のアクションを指定
-        cell.toggleButton.addTarget(self, action: #selector(hundleSwitch), for: UIControl.Event.valueChanged)
-        // モデルオブフェクトの取得 勘定別に取得
-        let objectss = DataBaseManagerJournalEntry.shared.getAllJournalEntryInAccountAll(
-            account: presenter.objects(
-                forRow: indexPath.row,
-                section: indexPath.section
-            ).category as String
-        ) // 通常仕訳　勘定別 全年度にしてはいけない
-        let objectsss = DataBaseManagerAdjustingEntry.shared.getAllAdjustingEntryInAccountAll(
-            account: presenter.objects(
-                forRow: indexPath.row,
-                section: indexPath.section
-            ).category as String
-        ) // 決算整理仕訳　勘定別　損益勘定以外 全年度にしてはいけない
-        
-        // 仕訳データが存在する場合、トグルスイッチはOFFにできないように、無効化する
-        if objectss.isEmpty && objectsss.isEmpty {
-            // UIButtonを有効化
-            cell.toggleButton.isEnabled = true
+        // 編集モードの場合
+        if tableView.isEditing {
+            // 勘定科目の有効無効
+            cell.toggleButton.isOn = presenter.objects(forRow: indexPath.row, section: indexPath.section).switching
+            // 勘定科目の有効無効　変更時のアクションを指定
+            cell.toggleButton.addTarget(self, action: #selector(hundleSwitch), for: UIControl.Event.valueChanged)
+            // モデルオブフェクトの取得 勘定別に取得
+            let objectss = DataBaseManagerJournalEntry.shared.getAllJournalEntryInAccountAll(
+                account: presenter.objects(
+                    forRow: indexPath.row,
+                    section: indexPath.section
+                ).category as String
+            ) // 通常仕訳　勘定別 全年度にしてはいけない
+            let objectsss = DataBaseManagerAdjustingEntry.shared.getAllAdjustingEntryInAccountAll(
+                account: presenter.objects(
+                    forRow: indexPath.row,
+                    section: indexPath.section
+                ).category as String
+            ) // 決算整理仕訳　勘定別　損益勘定以外 全年度にしてはいけない
+            
+            // 仕訳データが存在する場合、トグルスイッチはOFFにできないように、無効化する
+            if objectss.isEmpty && objectsss.isEmpty {
+                // UIButtonを有効化
+                cell.toggleButton.isEnabled = true
+            } else {
+                // UIButtonを無効化
+                cell.toggleButton.isEnabled = false
+            }
+            // UIButtonを表示
+            cell.toggleButton.isHidden = false
         } else {
-            // UIButtonを無効化
-            cell.toggleButton.isEnabled = false
+            // UIButtonを非表示
+            cell.toggleButton.isHidden = true
         }
         // Accessory Color
         let disclosureImage = UIImage(named: "navigate_next")?.withRenderingMode(.alwaysTemplate)

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListTableViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListTableViewController.swift
@@ -334,7 +334,7 @@ class CategoryListTableViewController: UITableViewController {
     
     // 編集機能
     override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        // デフォルトの勘定科目数（230）以上ある場合は、削除可能とし、それ以下の場合は削除不可とする。
+        // TODO: デフォルトの勘定科目数（230）以上ある場合は、削除可能とし、それ以下の場合は削除不可とする。
         if presenter.objects(forRow: indexPath.row, section: indexPath.section).number <= 229 {
             return .none // 削除不可
         }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/SplashViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/SplashViewController.swift
@@ -141,6 +141,15 @@ extension SplashViewController: SplashPresenterOutput {
             }
         }
     }
+
+    // パーセンテージを非表示させる
+    func hidePersentage() {
+        DispatchQueue.main.async {
+            if let whatIsDoingLabel = self.whatIsDoingLabel {
+                whatIsDoingLabel.isHidden = true
+            }
+        }
+    }
     
     // AppStore
     func goToAppStore() {

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/TB/AfterClosingTrialBalanceViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/TB/AfterClosingTrialBalanceViewController.swift
@@ -119,22 +119,28 @@ extension AfterClosingTrialBalanceViewController: UITableViewDelegate, UITableVi
 
     // MARK: - Table view data source
 
+    func numberOfSections(in tableView: UITableView) -> Int {
+        presenter.numberOfsections() + 1 // 合計額の行の分
+    }
     // セルの数
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // 合計額の行の分
-        return presenter.numberOfobjects + 1
+        if section < presenter.numberOfsections() {
+            presenter.numberOfobjects(section: section)
+        } else {
+            1 // 合計額の行の分
+        }
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.row < presenter.numberOfobjects {
+        if indexPath.section < presenter.numberOfsections() {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_TB", for: indexPath) as? TBTableViewCell else { return UITableViewCell() }
             // 勘定科目をセルに表示する
-            cell.accountLabel.text = "\(presenter.objects(forRow: indexPath.row).category as String)"
+            cell.accountLabel.text = "\(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)"
             cell.accountLabel.textAlignment = NSTextAlignment.center
             // 残高　借方　勘定別の決算整理後の合計額
-            cell.debitLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 2)
+            cell.debitLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)", leftOrRight: 2)
             // 残高　貸方　勘定別の決算整理後の合計額
-            cell.creditLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 3)
+            cell.creditLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)", leftOrRight: 3)
             return cell
         } else {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_last_TB", for: indexPath) as? TBTableViewCell else { return UITableViewCell() }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/TB/OpeningBalanceViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/TB/OpeningBalanceViewController.swift
@@ -12,26 +12,26 @@ import UIKit
 
 // 開始残高 openingBalance
 class OpeningBalanceViewController: UIViewController {
-
+    
     // MARK: - var let
-
+    
     /// 開始残高　上部
     @IBOutlet private var companyNameLabel: UILabel!
     @IBOutlet private var titleLabel: UILabel!
     @IBOutlet private var closingDateLabel: UILabel!
-
+    
     @IBOutlet private var printButton: UIButton!
     /// 開始残高　下部
     @IBOutlet private var tableView: UITableView!
     @IBOutlet private var backgroundView: EMTNeumorphicView!
     // グラデーションレイヤー　書類系画面
     let gradientLayer = CAGradientLayer()
-
+    
     let LIGHTSHADOWOPACITY: Float = 0.5
     //    let DARKSHADOWOPACITY: Float = 0.5
     let ELEMENTDEPTH: CGFloat = 4
     //    let edged = false
-
+    
     // 設定残高振替仕訳　連番
     var primaryKey: Int = 0
     // 勘定科目名
@@ -41,48 +41,48 @@ class OpeningBalanceViewController: UIViewController {
     // インジゲーター
     var activityIndicatorView = UIActivityIndicatorView()
     let backView = UIView()
-
+    
     /// GUIアーキテクチャ　MVP
     private var presenter: OpeningBalancePresenterInput!
     func inject(presenter: OpeningBalancePresenterInput) {
         self.presenter = presenter
     }
-
+    
     // MARK: - Life cycle
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         presenter = OpeningBalancePresenter.init(view: self, model: OpeningBalanceModel())
         inject(presenter: presenter)
-
+        
         presenter.viewDidLoad()
     }
-
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         presenter.viewWillAppear()
     }
-
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-
+        
         presenter.viewWillDisappear()
     }
-
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         presenter.viewDidAppear()
     }
-
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         // ボタン作成
         createButtons()
     }
-
+    
     // MARK: - Setting
-
+    
     private func setTableView() {
         tableView.delegate = self
         tableView.dataSource = self
@@ -92,10 +92,10 @@ class OpeningBalanceViewController: UIViewController {
         navigationItem.rightBarButtonItem = editButtonItem
         self.navigationItem.title = "開始残高"
     }
-
+    
     // ボタンのデザインを指定する
     private func createButtons() {
-
+        
         if let backgroundView = backgroundView {
             backgroundView.neumorphicLayer?.cornerRadius = 15
             backgroundView.neumorphicLayer?.lightShadowOpacity = LIGHTSHADOWOPACITY
@@ -118,7 +118,7 @@ class OpeningBalanceViewController: UIViewController {
             }
         }
     }
-
+    
     // 編集モード切り替え
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
@@ -230,56 +230,66 @@ class OpeningBalanceViewController: UIViewController {
             self.backView.removeFromSuperview()
         }
     }
-
+    
     // MARK: - Action
-
+    
     /**
      * 印刷ボタン押下時メソッド
      */
     @IBAction func printButtonTapped(_ sender: UIButton) {
-
+        
     }
 }
 
 extension OpeningBalanceViewController: UITableViewDelegate, UITableViewDataSource {
-
+    
     // MARK: - Table view data source
-
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        presenter.numberOfsections() + 1 // 合計額の行の分
+    }
     // セルの数
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // 合計額の行の分
-        return presenter.numberOfobjects + 1
+        if section < presenter.numberOfsections() {
+            presenter.numberOfobjects(section: section)
+        } else {
+            1 // 合計額の行の分
+        }
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.row < presenter.numberOfobjects {
+        if indexPath.section < presenter.numberOfsections() {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_TB", for: indexPath) as? OpeningBalanceTableViewCell else { return UITableViewCell() }
             // delegate設定
             cell.delegate = self
-
+            
             var account = ""
             var valueDebitText: Int64 = 0
             var valueCreditText: Int64 = 0
-
-            if presenter.objects(forRow: indexPath.row).debit_category == "残高" { // 借方
-                account = presenter.objects(forRow: indexPath.row).credit_category // 相手勘定科目名
-                valueDebitText = presenter.objects(forRow: indexPath.row).debit_amount
-            } else if presenter.objects(forRow: indexPath.row).credit_category == "残高" { // 貸方
-                account = presenter.objects(forRow: indexPath.row).debit_category // 相手勘定科目名
-                valueCreditText = presenter.objects(forRow: indexPath.row).credit_amount
-            }
-            // 編集中 は有効化
-            cell.textFieldAmountDebit.isEnabled = self.isEditing
-            cell.textFieldAmountCredit.isEnabled = self.isEditing
-
-            cell.setup(
-                primaryKey: presenter.objects(forRow: indexPath.row).number,
-                category: account,
-                valueDebitText: "\(valueDebitText)",
-                valueCreditText: "\(valueCreditText)"
-            ) { (textFieldAmountDebit, textFieldAmountCredit) in
-                cell.debitLabel.text = textFieldAmountDebit.text
-                cell.creditLabel.text = textFieldAmountCredit.text
+            // 設定勘定科目　の勘定名
+            let category = presenter.objects(forRow: indexPath.row, section: indexPath.section).category
+            // 設定残高振替仕訳 開始残高
+            if let dataBaseTransferEntry = presenter.objects(category: category) {
+                if dataBaseTransferEntry.debit_category == "残高" { // 借方
+                    account = dataBaseTransferEntry.credit_category // 相手勘定科目名
+                    valueDebitText = dataBaseTransferEntry.debit_amount
+                } else if dataBaseTransferEntry.credit_category == "残高" { // 貸方
+                    account = dataBaseTransferEntry.debit_category // 相手勘定科目名
+                    valueCreditText = dataBaseTransferEntry.credit_amount
+                }
+                // 編集中 は有効化
+                cell.textFieldAmountDebit.isEnabled = self.isEditing
+                cell.textFieldAmountCredit.isEnabled = self.isEditing
+                
+                cell.setup(
+                    primaryKey: dataBaseTransferEntry.number,
+                    category: account,
+                    valueDebitText: "\(valueDebitText)",
+                    valueCreditText: "\(valueCreditText)"
+                ) { (textFieldAmountDebit, textFieldAmountCredit) in
+                    cell.debitLabel.text = textFieldAmountDebit.text
+                    cell.creditLabel.text = textFieldAmountCredit.text
+                }
             }
             return cell
         } else {
@@ -299,22 +309,22 @@ extension OpeningBalanceViewController: UITableViewDelegate, UITableViewDataSour
             return cell
         }
     }
-
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         // segue.destinationの型はUIViewController
         if let controller = segue.destination as? ClassicCalculatorViewController {
-
+            
             controller.primaryKey = primaryKey
             controller.debitOrCredit = debitOrCredit
             controller.category = category
         }
     }
-
+    
     // 金額　電卓画面で入力した値を表示させる
     func setAmountValue(primaryKey: Int, numbersOnDisplay: Int, category: String, debitOrCredit: DebitOrCredit) {
         // 金額を入力後に、電卓画面から仕訳画面へ遷移した場合
         print(numbersOnDisplay, category, debitOrCredit)
-
+        
         presenter.setAmountValue(primaryKey: primaryKey, numbersOnDisplay: numbersOnDisplay, category: category, debitOrCredit: debitOrCredit)
     }
 }
@@ -329,13 +339,13 @@ extension OpeningBalanceViewController: InputTextTableCellDelegate {
         self.category = category
         // 借方金額　貸方金額
         self.debitOrCredit = debitOrCredit
-
+        
         self.view.endEditing(true)
     }
 }
 
 extension OpeningBalanceViewController: OpeningBalancePresenterOutput {
-
+    
     func reloadData() {
         // 更新処理
         DispatchQueue.main.async {
@@ -347,7 +357,7 @@ extension OpeningBalanceViewController: OpeningBalancePresenterOutput {
         // インジケーターを終了
         self.finishActivityIndicatorView()
     }
-
+    
     func setupViewForViewDidLoad() {
         // UI
         setTableView()
@@ -358,13 +368,13 @@ extension OpeningBalanceViewController: OpeningBalancePresenterOutput {
         //        self.navigationItem.rightBarButtonItem = printoutButton
         printButton.isHidden = true
     }
-
+    
     func setupViewForViewWillAppear() {
         if let company = presenter.company {
             // 月末、年度末などの決算日をラベルに表示する
             companyNameLabel.text = company // 社名
         }
-
+        
         if let theDayOfBeginningOfYear = presenter.theDayOfBeginningOfYear {
             if let fiscalYear = presenter.fiscalYear {
                 closingDateLabel.text = String(fiscalYear) + "年\(theDayOfBeginningOfYear.prefix(2))月\(theDayOfBeginningOfYear.suffix(2))日" // 決算日を表示する
@@ -372,17 +382,17 @@ extension OpeningBalanceViewController: OpeningBalancePresenterOutput {
         }
         titleLabel.text = "開始残高"
         titleLabel.font = UIFont.boldSystemFont(ofSize: 18)
-
+        
         // 要素数が少ないUITableViewで残りの部分や余白を消す
         let tableFooterView = UIView(frame: CGRect.zero)
         tableView.tableFooterView = tableFooterView
     }
-
+    
     func setupViewForViewWillDisappear() {
-
+        
     }
-
+    
     func setupViewForViewDidAppear() {
-
+        
     }
 }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/TB/TBViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/TB/TBViewController.swift
@@ -27,7 +27,7 @@ class TBViewController: UIViewController, UIPrintInteractionControllerDelegate {
     @IBOutlet private var backgroundView: EMTNeumorphicView!
     // グラデーションレイヤー　書類系画面
     let gradientLayer = CAGradientLayer()
-
+    
     let LIGHTSHADOWOPACITY: Float = 0.5
     //    let DARKSHADOWOPACITY: Float = 0.5
     let ELEMENTDEPTH: CGFloat = 4
@@ -66,10 +66,10 @@ class TBViewController: UIViewController, UIPrintInteractionControllerDelegate {
         super.viewWillAppear(animated)
         presenter.viewWillAppear()
     }
-
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-
+        
         presenter.viewWillDisappear()
     }
     
@@ -172,28 +172,34 @@ extension TBViewController: UITableViewDelegate, UITableViewDataSource {
     
     // MARK: - Table view data source
     
+    func numberOfSections(in tableView: UITableView) -> Int {
+        presenter.numberOfsections() + 1 // 合計額の行の分
+    }
     // セルの数
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // 合計額の行の分
-        return presenter.numberOfobjects + 1
+        if section < presenter.numberOfsections() {
+            presenter.numberOfobjects(section: section)
+        } else {
+            1 // 合計額の行の分
+        }
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.row < presenter.numberOfobjects {
+        if indexPath.section < presenter.numberOfsections() {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_TB", for: indexPath) as? TBTableViewCell else { return UITableViewCell() }
             // 勘定科目をセルに表示する
             //        cell.textLabel?.text = "\(presenter.objects(forRow:indexPath.row].category as String)"
-            cell.accountLabel.text = "\(presenter.objects(forRow: indexPath.row).category as String)"
+            cell.accountLabel.text = "\(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)"
             cell.accountLabel.textAlignment = NSTextAlignment.center
             switch segmentedControl.selectedSegmentIndex {
             case 0: // 合計　借方
-                cell.debitLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 0)
+                cell.debitLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)", leftOrRight: 0)
                 // 合計　貸方
-                cell.creditLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 1)
+                cell.creditLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)", leftOrRight: 1)
             case 1: // 残高　借方
-                cell.debitLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 2)
+                cell.debitLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)", leftOrRight: 2)
                 // 残高　貸方
-                cell.creditLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 3)
+                cell.creditLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)", leftOrRight: 3)
             default:
                 print("cell_TB")
             }
@@ -283,7 +289,7 @@ extension TBViewController: TBPresenterOutput {
             }
         }
     }
-
+    
     func setupViewForViewWillDisappear() {
         // アップグレード機能　スタンダードプラン
         if let gADBannerView = gADBannerView {
@@ -291,7 +297,7 @@ extension TBViewController: TBPresenterOutput {
             removeBannerViewToView(gADBannerView)
         }
     }
-
+    
     func setupViewForViewDidAppear() {
         // チュートリアル対応 コーチマーク型　初回起動時　7行を追加
         let userDefaults = UserDefaults.standard

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/UIParts/ViewController/CarouselAndPageViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/UIParts/ViewController/CarouselAndPageViewController.swift
@@ -194,7 +194,6 @@ extension CarouselAndPageViewController: UIPageViewControllerDelegate, UIPageVie
             // タブの選択位置を更新する
             // セルを選択して、コレクションビューの中の中心へスクロールさせる
             self.carouselCollectionView.selectItem(at: IndexPath(row: selectedIndex, section: 0), animated: true, scrollPosition: .centeredHorizontally)
-
         }
     }
 }

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/WS/WSViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/WS/WSViewController.swift
@@ -208,32 +208,45 @@ extension WSViewController: UITableViewDelegate, UITableViewDataSource {
     
     // MARK: - Table view data source
     
+    func numberOfSections(in tableView: UITableView) -> Int {
+        presenter.numberOfsections() + 1 + 1 + 1
+        // + 残高試算表合計の行 + 当期純利益 + 修正記入、損益計算書、貸借対照表の合計の行
+    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        
-        presenter.numberOfobjects + 1 + presenter.numberOfobjectss + 1 + 1  // + 試算表合計の行の分+修正記入の行の分+当期純利益+修正記入、損益計算書、貸借対照表の合計の分
+        if section < presenter.numberOfsections() {
+            presenter.numberOfobjects(section: section)
+        } else {
+            1 // + 残高試算表合計の行 + 当期純利益 + 修正記入、損益計算書、貸借対照表の合計の行
+        }
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         // セル　決算整理前残高試算表の行
-        if indexPath.row < presenter.numberOfobjects {
+        if indexPath.section < presenter.numberOfsections() {
             // ① UI部品を指定
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_WS", for: indexPath) as? WSTableViewCell else { return UITableViewCell() }
+            // 設定勘定科目　の勘定名
+            let category = presenter.objects(forRow: indexPath.row, section: indexPath.section).category
             // 勘定科目をセルに表示する
-            cell.accountLabel.text = "\(presenter.objects(forRow: indexPath.row).category as String)"
+            cell.accountLabel.text = category
             cell.accountLabel.textAlignment = NSTextAlignment.center
             // 決算整理前残高試算表
-            cell.debitLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 2)
+            cell.debitLabel.text = presenter.getTotalAmount(account: category, leftOrRight: 2)
             cell.debitLabel.textAlignment = NSTextAlignment.right
-            cell.creditLabel.text = presenter.getTotalAmount(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 3)
+            cell.creditLabel.text = presenter.getTotalAmount(account: category, leftOrRight: 3)
             cell.creditLabel.textAlignment = NSTextAlignment.right
             cell.debitLabel.backgroundColor = .clear
             cell.creditLabel.backgroundColor = .clear
-            switch Int(presenter.objects(forRow: indexPath.row).Rank0) {
+            
+            // 設定勘定科目　の勘定名
+            let Rank0 = presenter.objects(forRow: indexPath.row, section: indexPath.section).Rank0
+            switch Int(Rank0) {
             case 0, 1, 2, 3, 4, 5, 12: // 大分類　貸借対照表：0,1,2
                 // 修正記入
-                cell.debit1Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 0)
+                cell.debit1Label.text = presenter.getTotalAmountAdjusting(account: category, leftOrRight: 0)
                 cell.debit1Label.textAlignment = NSTextAlignment.right
-                cell.credit1Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 1)
+                cell.credit1Label.text = presenter.getTotalAmountAdjusting(account: category, leftOrRight: 1)
                 cell.credit1Label.textAlignment = NSTextAlignment.right
                 cell.debit1Label.backgroundColor = .clear
                 cell.credit1Label.backgroundColor = .clear
@@ -243,24 +256,24 @@ extension WSViewController: UITableViewDelegate, UITableViewDataSource {
                 cell.debit2Label.backgroundColor = .mainColor
                 cell.credit2Label.backgroundColor = .mainColor
                 // 貸借対照表 修正記入の分を差し引きして、表示する　WSModelを作成して処理を記述する
-                cell.debit3Label.text = presenter.getTotalAmountAfterAdjusting(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 2)
+                cell.debit3Label.text = presenter.getTotalAmountAfterAdjusting(account: category, leftOrRight: 2)
                 cell.debit3Label.textAlignment = NSTextAlignment.right
-                cell.credit3Label.text = presenter.getTotalAmountAfterAdjusting(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 3)
+                cell.credit3Label.text = presenter.getTotalAmountAfterAdjusting(account: category, leftOrRight: 3)
                 cell.credit3Label.textAlignment = NSTextAlignment.right
                 cell.debit3Label.backgroundColor = .clear
                 cell.credit3Label.backgroundColor = .clear
             case 6, 7, 8, 9, 10, 11: // 大分類 損益計算書：3,4
                 // 修正記入
-                cell.debit1Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 0)
+                cell.debit1Label.text = presenter.getTotalAmountAdjusting(account: category, leftOrRight: 0)
                 cell.debit1Label.textAlignment = NSTextAlignment.right
-                cell.credit1Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 1)
+                cell.credit1Label.text = presenter.getTotalAmountAdjusting(account: category, leftOrRight: 1)
                 cell.credit1Label.textAlignment = NSTextAlignment.right
                 cell.debit1Label.backgroundColor = .clear
                 cell.credit1Label.backgroundColor = .clear
                 // 損益計算書
-                cell.debit2Label.text = presenter.getTotalAmountAfterAdjusting(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 2)
+                cell.debit2Label.text = presenter.getTotalAmountAfterAdjusting(account: category, leftOrRight: 2)
                 cell.debit2Label.textAlignment = NSTextAlignment.right
-                cell.credit2Label.text = presenter.getTotalAmountAfterAdjusting(account: "\(presenter.objects(forRow: indexPath.row).category as String)", leftOrRight: 3)
+                cell.credit2Label.text = presenter.getTotalAmountAfterAdjusting(account: category, leftOrRight: 3)
                 cell.credit2Label.textAlignment = NSTextAlignment.right
                 cell.debit2Label.backgroundColor = .clear
                 cell.credit2Label.backgroundColor = .clear
@@ -273,69 +286,16 @@ extension WSViewController: UITableViewDelegate, UITableViewDataSource {
                 print("a")
             }
             return cell
-        } else if indexPath.row == presenter.numberOfobjects { // セル　試算表の合計の行
+        } else if indexPath.section < presenter.numberOfsections() + 1 {
+            // 試算表の合計の行
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_WS_total", for: indexPath) as? WSTableViewCell else { return UITableViewCell() }
             cell.accountLabel.text = ""
             // 決算整理前残高試算表
             cell.debitLabel.text = presenter.debit_balance_total()
             cell.creditLabel.text = presenter.credit_balance_total()
             return cell
-        } else if indexPath.row < presenter.numberOfobjects + 1 + presenter.numberOfobjectss { // セル　修正記入の行
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_WS", for: indexPath) as? WSTableViewCell else { return UITableViewCell() }
-            // 勘定科目をセルに表示する
-            cell.accountLabel.text = "\(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).category as String)"
-            cell.accountLabel.textAlignment = NSTextAlignment.center
-            // 決算整理前残高試算表
-            cell.debitLabel.text = ""
-            cell.creditLabel.text = ""
-            cell.debitLabel.backgroundColor = .mainColor
-            cell.creditLabel.backgroundColor = .mainColor
-            switch Int(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).Rank2) {
-            case 0, 1, 2, 3, 4, 5, 12: // 大分類　貸借対照表：0,1,2
-                // 修正記入
-                cell.debit1Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).category as String)", leftOrRight: 0)
-                cell.debit1Label.textAlignment = NSTextAlignment.right
-                cell.credit1Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).category as String)", leftOrRight: 1)
-                cell.credit1Label.textAlignment = NSTextAlignment.right
-                cell.debit1Label.backgroundColor = .clear
-                cell.credit1Label.backgroundColor = .clear
-                // 損益計算書
-                cell.debit2Label.text = ""
-                cell.credit2Label.text = ""
-                cell.debit2Label.backgroundColor = .clear
-                cell.credit2Label.backgroundColor = .clear
-                // 貸借対照表
-                cell.debit3Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).category as String)", leftOrRight: 2)
-                cell.debit3Label.textAlignment = NSTextAlignment.right
-                cell.credit3Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).category as String)", leftOrRight: 3)
-                cell.credit3Label.textAlignment = NSTextAlignment.right
-                cell.debit3Label.backgroundColor = .clear
-                cell.credit3Label.backgroundColor = .clear
-            case 6, 7, 8, 9, 10, 11: // 大分類 損益計算書：3,4
-                // 修正記入
-                cell.debit1Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).category as String)", leftOrRight: 0)
-                cell.debit1Label.textAlignment = NSTextAlignment.right
-                cell.credit1Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).category as String)", leftOrRight: 1)
-                cell.credit1Label.textAlignment = NSTextAlignment.right
-                cell.debit1Label.backgroundColor = .clear
-                cell.credit1Label.backgroundColor = .clear
-                // 損益計算書
-                cell.debit2Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).category as String)", leftOrRight: 2)
-                cell.debit2Label.textAlignment = NSTextAlignment.right
-                cell.credit2Label.text = presenter.getTotalAmountAdjusting(account: "\(presenter.objectss(forRow: indexPath.row - (presenter.numberOfobjects + 1)).category as String)", leftOrRight: 3)
-                cell.credit2Label.textAlignment = NSTextAlignment.right
-                cell.debit2Label.backgroundColor = .clear
-                cell.credit2Label.backgroundColor = .clear
-                // 貸借対照表
-                cell.debit3Label.text = ""
-                cell.credit3Label.text = ""
-                cell.debit3Label.backgroundColor = .clear
-                cell.credit3Label.backgroundColor = .clear
-            default: // 大分類　貸借対照表：0,1,2 損益計算書：3,4
-                print("aa")
-            }
-            return cell
-        } else if indexPath.row < presenter.numberOfobjects + 1 + presenter.numberOfobjectss + 1 { // セル　当期純利益の行
+        } else if indexPath.section < presenter.numberOfsections() + 1 + 1 {
+            // 当期純利益の行
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_WS", for: indexPath) as? WSTableViewCell else { return UITableViewCell() }
             // 勘定科目をセルに表示する
             cell.accountLabel.text = "当期純利益"
@@ -365,7 +325,8 @@ extension WSViewController: UITableViewDelegate, UITableViewDataSource {
             cell.debit3Label.backgroundColor = .clear
             cell.credit3Label.backgroundColor = .clear
             return cell
-        } else if indexPath.row < presenter.numberOfobjects + 1 + presenter.numberOfobjectss + 1 + 1 { // セル　修正記入と損益計算書、貸借対照表の合計の行
+        } else if indexPath.section < presenter.numberOfsections() + 1 + 1 + 1 {
+            // 修正記入と損益計算書、貸借対照表の合計の行
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_WS_total_2", for: indexPath) as? WSTableViewCell else { return UITableViewCell() }
             cell.accountLabel.text = ""
             // 決算整理前残高試算表


### PR DESCRIPTION
Close #221

[勘定科目一覧画面] 編集モード以外の時は、使用していない勘定科目を非表示させる

編集モード中
・編集ボタンが完了ボタンに切り替わるように修正
・スイッチを表示させる
・使用していない勘定科目を表示させる
　・PageViewをスワイプしたタイミング
　・カルーセルのタブをタップされたとき

通常時
・使用していない勘定科目を非表示させる セルの高さを0にする。

[勘定科目一覧画面] 勘定科目の順序変更

編集モード中
・並び順を変えられるようにする ドラッグ&ドロップ　別の中区分へ移動させようとした場合、トーストを表示させる。

勘定科目番号 プロパティを追加する 連番とは別のもの　
勘定科目のシリアルナンバー 初期値は連番
　元入金
　事業主借
　事業主貸
　新規の勘定科目
データベース　マイグレーション
CSVファイル　マスターデータ読み込み処理

勘定科目番号 使用している勘定科目のみで、採番する
　勘定科目のシリアルナンバー

勘定科目名
バリデーション処理を整理
入力中に確定していない文字をバックキーで削除できない不具合を修正
文字数最大数　19文字になっていたので、20文字へ修正
キーボードのツールバーの色を変更

[総勘定元帳画面] 勘定科目の順序変更　中区分ごとに表示させる

[その他][勘定科目詳細画面] 編集機能を実装

編集ボタンを設置する　使用しないように蓋をしている
編集可能とする 勘定科目名
レイアウト調整　勘定科目名 区分
同名　バリデーション
登　録ボタンの文言のサイズを変更

TableViewCellのクラスをひとつに統一した
・入力カーソル非表示
・範囲選択カーソル非表示
・コピー・ペースト・選択等のメニュー非表示