### PR TITLE
最新のバージョンなのにバージョンアップダイアログが表示される

### DIFF
--- a/iOS/Accountant/v1.0/Program/src/Accountant/Model/SplashModel.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Model/SplashModel.swift
@@ -71,11 +71,19 @@ class SplashModel: SplashModelInput {
                     return
                 }
                 // 端末のアプリバージョンと App Store のアプリバージョンを比較
-                print(appVersion, storeVersion, appVersion < storeVersion)
-                if appVersion < storeVersion {
+                // if appVersion < storeVersion { // NOTE: 文字列比較　< の場合、String型で比較しているので、5.10.0 < 5.9.0 がtrueになってしまう（falseが正しい）
+                guard let currentVersion = AppVersion(appVersion),
+                      let requiredVersion = AppVersion(storeVersion) else {
+                    completionHandler(false)
+                    return
+                }
+                print(appVersion, storeVersion, "文字列比較", appVersion < storeVersion, "数値比較", currentVersion < requiredVersion)
+                if currentVersion < requiredVersion {
+                    print("requiredVersionの方が大きい")
                     // appVersion と storeVersion が異なっている時に実行したい処理
                     completionHandler(true)
                 } else {
+                    print("currentVersionの方が大きい")
                     completionHandler(false)
                 }
             } catch let error {

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Utils/AppVersion.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Utils/AppVersion.swift
@@ -8,8 +8,26 @@
 
 import Foundation
 
-public struct AppVersion {
+struct AppVersion {
     
+    let versionString: String // アプリバージョン文字列
+    let majorVersion: Int // メジャーバージョン
+    let minorVersion: Int // マイナーバージョン
+    let patchVersion: Int // パッチバージョン
+    
+    init?(_ version: String) {
+        let versionNumbers = version.components(separatedBy: ".").compactMap { Int($0) }
+        if versionNumbers.count == 3 {
+            versionString = version
+            majorVersion = versionNumbers[0]
+            minorVersion = versionNumbers[1]
+            patchVersion = versionNumbers[2]
+        } else {
+            print("Does not meet the conditions of Semantic Versioning. App Version: \(version)")
+            return nil
+        }
+    }
+
     static var currentVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0.0"
     }
@@ -35,4 +53,72 @@ public struct AppVersion {
     //        let revision = String(format: "%02d", Int(versionList[2]) ?? 0)
     //        return Int(major + minor + revision) ?? 10_000
     //    }
+}
+
+// MARK: - AppVersion Comparable Functions
+extension AppVersion: Comparable {
+
+    // 左辺と右辺は等しい
+    static func == (lhs: AppVersion, rhs: AppVersion) -> Bool {
+
+        if lhs.majorVersion == rhs.majorVersion,
+           lhs.minorVersion == rhs.minorVersion,
+           lhs.patchVersion == rhs.patchVersion {
+            return true
+        }
+
+        return false
+    }
+
+    // 左辺は右辺より小さい
+    static func < (lhs: AppVersion, rhs: AppVersion) -> Bool {
+
+        if lhs.majorVersion != rhs.majorVersion {
+            return lhs.majorVersion < rhs.majorVersion
+        }
+        if lhs.minorVersion != rhs.minorVersion {
+            return lhs.minorVersion < rhs.minorVersion
+        }
+        if lhs.patchVersion != rhs.patchVersion {
+            return lhs.patchVersion < rhs.patchVersion
+        }
+
+        return false
+    }
+
+    // 左辺は右辺より大きい
+    static func > (lhs: AppVersion, rhs: AppVersion) -> Bool {
+
+        if lhs.majorVersion != rhs.majorVersion {
+            return lhs.majorVersion > rhs.majorVersion
+        }
+        if lhs.minorVersion != rhs.minorVersion {
+            return lhs.minorVersion > rhs.minorVersion
+        }
+        if lhs.patchVersion != rhs.patchVersion {
+            return lhs.patchVersion > rhs.patchVersion
+        }
+
+        return false
+    }
+
+    // 左辺は右辺以下
+    static func <= (lhs: AppVersion, rhs: AppVersion) -> Bool {
+
+        if lhs == rhs {
+            return true
+        }
+
+        return lhs < rhs
+    }
+
+    // 左辺は右辺以上
+    static func >= (lhs: AppVersion, rhs: AppVersion) -> Bool {
+
+        if lhs == rhs {
+            return true
+        }
+
+        return lhs > rhs
+    }
 }


### PR DESCRIPTION
Close #293

[その他][スプラッシュ画面] バージョンアップダイアログ
iPhone のアプリバージョンと、AppStoreのアプリバージョンの比較処理を改修する
文字列比較では想定した結果にならなかった為、AppVersionという構造体を作成してアプリバージョンを比較出来るようにします。 メジャーバージョンが二桁のケースと一桁の比較