### PR TITLE
勘定科目を設定しても仕訳画面の選択肢に表示されない

### DIFF
--- a/iOS/Accountant/v1.0/Program/src/Accountant/Constant.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Constant.swift
@@ -73,6 +73,8 @@ enum Constant {
     
     // 月次推移表を更新する　true: リロードする
     static var needToReload = false
+    // 仕訳画面の勘定科目を更新する　true: リロードする
+    static var needToReloadCategory = false
     
     // MARK: レビュー促進ダイアログ
     

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/JournalEntry/JournalEntryViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/JournalEntry/JournalEntryViewController.swift
@@ -3022,6 +3022,55 @@ extension JournalEntryViewController: JournalEntryPresenterOutput {
                 journalEntryType = .CompoundJournalEntry // 仕訳 複合仕訳　タブバーの仕訳タブからの遷移の場合
             }
         }
+        // 仕訳画面の勘定科目を更新する
+        if Constant.needToReloadCategory {
+            // 取引要素　借方 貸方　クリア
+            debit = AccountTitleAmount()
+            credit = AccountTitleAmount()
+            // 仕訳タイプ判定
+            if journalEntryType == .CompoundJournalEntry { // 仕訳 複合仕訳　タブバーの仕訳タブからの遷移の場合
+                creditElements = []
+                debitElements = []
+            }
+            // 勘定科目
+            if let textFieldCategoryDebit = textFieldCategoryDebit {
+                textFieldCategoryDebit.updateUI()
+            }
+            if let textFieldCategoryCredit = textFieldCategoryCredit {
+                textFieldCategoryCredit.updateUI()
+            }
+            // 仕訳タイプ判定
+            if journalEntryType == .CompoundJournalEntry { // 仕訳 複合仕訳　タブバーの仕訳タブからの遷移の場合
+                // 勘定科目
+                if let textFieldCategoryDebit1 = textFieldCategoryDebit1 {
+                    textFieldCategoryDebit1.updateUI()
+                }
+                if let textFieldCategoryCredit1 = textFieldCategoryCredit1 {
+                    textFieldCategoryCredit1.updateUI()
+                }
+                if let textFieldCategoryDebit2 = textFieldCategoryDebit2 {
+                    textFieldCategoryDebit2.updateUI()
+                }
+                if let textFieldCategoryCredit2 = textFieldCategoryCredit2 {
+                    textFieldCategoryCredit2.updateUI()
+                }
+                if let textFieldCategoryDebit3 = textFieldCategoryDebit3 {
+                    textFieldCategoryDebit3.updateUI()
+                }
+                if let textFieldCategoryCredit3 = textFieldCategoryCredit3 {
+                    textFieldCategoryCredit3.updateUI()
+                }
+                if let textFieldCategoryDebit4 = textFieldCategoryDebit4 {
+                    textFieldCategoryDebit4.updateUI()
+                }
+                if let textFieldCategoryCredit4 = textFieldCategoryCredit4 {
+                    textFieldCategoryCredit4.updateUI()
+                }
+            }
+            self.view.endEditing(true)
+            // 仕訳画面の勘定科目を更新する　true: リロードする
+            Constant.needToReloadCategory = false
+        }
         // 仕訳タイプ判定
         if journalEntryType == .CompoundJournalEntry { // 仕訳 複合仕訳　タブバーの仕訳タブからの遷移の場合
             // タブバーの仕訳タブからの遷移の場合 表示させる

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Journals/Journals/JournalsViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Journals/Journals/JournalsViewController.swift
@@ -327,11 +327,9 @@ class JournalsViewController: UIViewController, UIGestureRecognizerDelegate {
         // 選択されたセル
         if let indexPathsForSelectedRows = self.tableView.indexPathsForSelectedRows {
             let sortedIndexPaths = indexPathsForSelectedRows.sorted { $0.row > $1.row }
-            for indexPath in sortedIndexPaths {
-                // 選択されたセルに表示していたデータ(仕訳オブジェクトのindexPath)を配列にまとめる
-                self.indexPaths.append(indexPath) // アンラップする
-            }
-            
+            // 選択されたセルに表示していたデータ(仕訳オブジェクトのindexPath)を配列にまとめる
+            self.indexPaths = sortedIndexPaths
+
             // ①UIAlertControllerクラスのインスタンスを生成する
             // titleにタイトル, messegeにメッセージ, prefereedStyleにスタイルを指定する
             // preferredStyleにUIAlertControllerStyle.actionSheetを指定してアクションシートを表示する

--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/CategoryListPresenter.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Presenter/CategoryListPresenter.swift
@@ -476,6 +476,8 @@ final class CategoryListPresenter: CategoryListPresenterInput {
     func changeSwitch(tag: Int, isOn: Bool) {
         // 引数：連番、トグルスイッチ.有効無効
         model.updateSettingsCategorySwitching(tag: tag, isOn: isOn)
+        // 仕訳画面の勘定科目を更新する　true: リロードする
+        Constant.needToReloadCategory = true
     }
     
     // 採番　設定勘定科目 並び替えの順序のためのシリアルナンバーを更新する


### PR DESCRIPTION
colse #295


[不具合修正][仕訳画面] 勘定科目を設定しても仕訳画面の選択肢に表示されない現象を改善
設定勘定科目一覧画面で科目のスイッチを変更した際に、フラグを立てる。
仕訳画面でフラグが立っていれば、テキストフィールドをリロードさせる。

[不具合修正][仕訳帳画面] 選択した項目を編集ボタンから表示させるアクションシートのタイトルの仕訳の件数が不正だった