### PR TITLE
勘定科目一覧画面の使用していない勘定科目の文字色をグレーアウトする

### DIFF
--- a/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListTableViewController.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/View/Settings/SettingsCategoryList/CategoryListTableViewController.swift
@@ -215,9 +215,14 @@ class CategoryListTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         // ① UI部品を指定　TableViewCellCategory
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell_list_category", for: indexPath) as? CategoryListTableViewCell else { return UITableViewCell() }
+        // 勘定科目の有効無効
+        if presenter.objects(forRow: indexPath.row, section: indexPath.section).switching {
+            cell.textLabel?.textColor = .textColor
+        } else {
+            cell.textLabel?.textColor = .mainColor
+        }
         // 勘定科目の名称をセルに表示する 丁数(元丁) 勘定名
         cell.textLabel?.text = " \(presenter.objects(forRow: indexPath.row, section: indexPath.section).number). \(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)"
-        cell.textLabel?.textColor = .textColor
         //        cell.label_category.text = " \(presenter.objects(forRow: indexPath.row, section: indexPath.section).category as String)"
         // 勘定科目の連番
         cell.tag = presenter.objects(forRow: indexPath.row, section: indexPath.section).number


### PR DESCRIPTION
close #307

[新機能][勘定科目一覧画面] 使用していない勘定科目の文字色をグレーアウトする

| Header | Header |
|--------|--------|
| ![IMG_5873](https://github.com/user-attachments/assets/3b968e36-64dc-436d-a3e2-9a58b8c69869) | ![IMG_5875](https://github.com/user-attachments/assets/51bfedfb-6540-4da5-9e47-87c851434d48) | 
