### PR TITLE
PDFのレイアウトが崩れる　差し戻し2

### DIFF
--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/PDF/HTMLhelperBS.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/PDF/HTMLhelperBS.swift
@@ -278,8 +278,8 @@ struct HTMLhelperBS {
         <section class="page">
             <div class="richediter public-notice l-container">
 
+                <p class="text-right">\(DateManager.shared.getDate())</p>
                 <h2>貸借対照表</h2>
-                <div><p class="text-right">\(DateManager.shared.getDate())</p></div>
                 <div class="flex">
                     <span class="halfWidth">\(company)</span>
                     <span class="halfWidth"><p class="right"> (\(theDayOfReckoning == "12/31" ? fiscalYear : fiscalYear + 1)/\(theDayOfReckoning) 現在)<br> (単位:円)<br><br>No.　　　\(pageNumber)</p></span>

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/PDF/HTMLhelperMonthlyBS.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/PDF/HTMLhelperMonthlyBS.swift
@@ -284,8 +284,8 @@ struct HTMLhelperMonthlyBS {
         <section class="page">
             <div class="richediter public-notice l-container">
     
+                <p class="text-right">\(DateManager.shared.getDate())</p>
                 <h2>貸借対照表</h2>
-                <div><p class="text-right">\(DateManager.shared.getDate())</p></div>
                 <div class="flex">
                     <span class="halfWidth">\(company)</span>
                     <span class="halfWidth"><p class="right"> (\(theDayOfReckoning == "12/31" ? fiscalYear : fiscalYear + 1)/\(theDayOfReckoning) 現在)<br> (単位:円)<br><br>No.　　　\(pageNumber)</p></span>

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/PDF/HTMLhelperMonthlyPL.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/PDF/HTMLhelperMonthlyPL.swift
@@ -284,8 +284,8 @@ struct HTMLhelperMonthlyPL {
         <section class="page">
             <div class="richediter public-notice l-container">
     
+                <p class="text-right">\(DateManager.shared.getDate())</p>
                 <h2>損益計算書</h2>
-                <div><p class="text-right">\(DateManager.shared.getDate())</p></div>
                 <div class="flex">
                     <span class="halfWidth">\(company)</span>
                     <span class="halfWidth"><p class="right"> (\(theDayOfReckoning == "12/31" ? fiscalYear : fiscalYear + 1)/\(theDayOfReckoning) 現在)<br> (単位:円)<br><br>No.　　　\(pageNumber)</p></span>

--- a/iOS/Accountant/v1.0/Program/src/Accountant/Functions/PDF/HTMLhelperPL.swift
+++ b/iOS/Accountant/v1.0/Program/src/Accountant/Functions/PDF/HTMLhelperPL.swift
@@ -281,8 +281,8 @@ struct HTMLhelperPL {
         <section class="page">
             <div class="richediter public-notice l-container">
     
+                <p class="text-right">\(DateManager.shared.getDate())</p>
                 <h2>損益計算書</h2>
-                <div><p class="text-right">\(DateManager.shared.getDate())</p></div>
                 <div class="flex">
                     <span class="halfWidth">\(company)</span>
                     <span class="halfWidth"><p class="right"> (\(theDayOfReckoning == "12/31" ? fiscalYear : fiscalYear + 1)/\(theDayOfReckoning) 現在)<br> (単位:円)<br><br>No.　　　\(pageNumber)</p></span>


### PR DESCRIPTION
Close https://github.com/YingZheng02590218/iKingdom/issues/304

[不具合修正][貸借対照表画面] PDF機能　レイアウト崩れを修正

[不具合修正][損益計算書画面] PDF機能　レイアウト崩れを修正

[不具合修正][月次推移表画面] 貸借対照表　PDF機能　レイアウト崩れを修正

[不具合修正][月次推移表画面] 損益計算書　PDF機能　レイアウト崩れを修正